### PR TITLE
Typos and ImapStream.Flush fix

### DIFF
--- a/MailKit/Net/Imap/ImapClient.cs
+++ b/MailKit/Net/Imap/ImapClient.cs
@@ -62,7 +62,7 @@ namespace MailKit.Net.Imap {
 		readonly IProtocolLogger logger;
 		readonly ImapEngine engine;
 #if NETFX_CORE || WINDOWS_APP || WINDOWS_PHONE_APP
-		StreamSocket Socket;
+        StreamSocket socket;
 #endif
 		bool disposed;
 		string host;
@@ -594,7 +594,7 @@ namespace MailKit.Net.Imap {
 
 #if NETFX_CORE || WINDOWS_APP || WINDOWS_PHONE_APP
 			socket.Dispose ();
-			Socket = null;
+			socket = null;
 #endif
 		}
 

--- a/MailKit/Net/Imap/ImapStream.cs
+++ b/MailKit/Net/Imap/ImapStream.cs
@@ -796,6 +796,7 @@ namespace MailKit.Net.Imap {
 
 			try {
 				Stream.Write (output, 0, outputIndex);
+                Stream.Flush ();
 				logger.LogClient (output, 0, outputIndex);
 				outputIndex = 0;
 			} catch (IOException) {


### PR DESCRIPTION
Fixing a couple minor typos and making sure the output stream is flushed when ImapStream.Flush is called.
