### PR TITLE
Add a check for null ParentFolder to Rename

### DIFF
--- a/MailKit/Net/Imap/ImapFolder.cs
+++ b/MailKit/Net/Imap/ImapFolder.cs
@@ -726,7 +726,8 @@ namespace MailKit.Net.Imap {
 			Engine.FolderCache.Remove (EncodedName);
 			Engine.FolderCache[encodedName] = this;
 
-			ParentFolder.Renamed -= ParentFolderRenamed;
+            if (ParentFolder != null)
+			    ParentFolder.Renamed -= ParentFolderRenamed;
 			SetParentFolder (parent);
 
 			FullName = ImapEncoding.Decode (encodedName);


### PR DESCRIPTION
It is possible for a ParentFolder to be null, if the ParentFolder has
never been populated. This can happen when the Folder has been created
in the current session. Renaming this folder would throw a null value
Exception. This fixes it.
