### PR TITLE
Protecting against exceptions when setting stream timeout

### DIFF
--- a/MailKit/Net/Imap/ImapClient.cs
+++ b/MailKit/Net/Imap/ImapClient.cs
@@ -259,7 +259,7 @@ namespace MailKit.Net.Imap {
 		public int Timeout {
 			get { return timeout; }
 			set {
-				if (IsConnected) {
+				if (IsConnected && engine.Stream.CanTimeout) {
 					engine.Stream.WriteTimeout = value;
 					engine.Stream.ReadTimeout = value;
 				}
@@ -538,8 +538,10 @@ namespace MailKit.Net.Imap {
 			stream = new DuplexStream (socket.InputStream.AsStreamForRead (), socket.OutputStream.AsStreamForWrite ());
 #endif
 
-			stream.WriteTimeout = timeout;
-			stream.ReadTimeout = timeout;
+			if (stream.CanTimeout) {
+				stream.WriteTimeout = timeout;
+				stream.ReadTimeout = timeout;
+			}
 			host = uri.Host;
 
 			logger.LogConnect (uri);

--- a/MailKit/Net/Pop3/Pop3Client.cs
+++ b/MailKit/Net/Pop3/Pop3Client.cs
@@ -295,7 +295,7 @@ namespace MailKit.Net.Pop3 {
 		public int Timeout {
 			get { return timeout; }
 			set {
-				if (IsConnected) {
+				if (IsConnected && engine.Stream.CanTimeout) {
 					engine.Stream.WriteTimeout = value;
 					engine.Stream.ReadTimeout = value;
 				}
@@ -600,8 +600,10 @@ namespace MailKit.Net.Pop3 {
 #endif
 
 			probed = ProbedCapabilities.None;
-			stream.WriteTimeout = timeout;
-			stream.ReadTimeout = timeout;
+			if (stream.CanTimeout) {
+				stream.WriteTimeout = timeout;
+				stream.ReadTimeout = timeout;
+			}
 			host = uri.Host;
 
 			logger.LogConnect (uri);

--- a/MailKit/Net/Smtp/SmtpClient.cs
+++ b/MailKit/Net/Smtp/SmtpClient.cs
@@ -217,7 +217,7 @@ namespace MailKit.Net.Smtp {
 		public int Timeout {
 			get { return timeout; }
 			set {
-				if (IsConnected) {
+				if (IsConnected && stream.CanTimeout) {
 					stream.WriteTimeout = value;
 					stream.ReadTimeout = value;
 				}
@@ -763,8 +763,10 @@ namespace MailKit.Net.Smtp {
 			stream = new DuplexStream (socket.InputStream.AsStreamForRead (), socket.OutputStream.AsStreamForWrite ());
 #endif
 
-			stream.WriteTimeout = timeout;
-			stream.ReadTimeout = timeout;
+			if (stream.CanTimeout) {
+				stream.WriteTimeout = timeout;
+				stream.ReadTimeout = timeout;
+			}
 			host = uri.Host;
 
 			logger.LogConnect (uri);


### PR DESCRIPTION
Adding checks to CanTimeout in case a particular platform doesn't support setting the timeout on streams.
