### PR TITLE
Patch for parsing message/rfc822 body from GMail.

### DIFF
--- a/MailKit/Net/Imap/ImapUtils.cs
+++ b/MailKit/Net/Imap/ImapUtils.cs
@@ -632,18 +632,23 @@ namespace MailKit.Net.Imap {
 				if (engine.IsGMail) {
 					// GMail's support for message/rfc822 body parts is broken, see issue #32
 					token = engine.PeekToken (cancellationToken);
-					if (token.Type != ImapTokenType.CloseParen) {
-						mesg.Envelope = ParseEnvelope (engine, cancellationToken);
-						token = engine.PeekToken (cancellationToken);
-					}
+					if (token.Type == ImapTokenType.OpenParen)
+					{
+						if (token.Type != ImapTokenType.CloseParen)
+						{
+							mesg.Envelope = ParseEnvelope(engine, cancellationToken);
+							token = engine.PeekToken(cancellationToken);
+						}
 
-					if (token.Type != ImapTokenType.CloseParen) {
-						mesg.Body = ParseBody (engine, path, cancellationToken);
-						token = engine.PeekToken (cancellationToken);
-					}
+						if (token.Type != ImapTokenType.CloseParen)
+						{
+							mesg.Body = ParseBody(engine, path, cancellationToken);
+							token = engine.PeekToken(cancellationToken);
+						}
 
-					if (token.Type != ImapTokenType.CloseParen)
-						mesg.Lines = ReadNumber (engine, cancellationToken);
+						if (token.Type != ImapTokenType.CloseParen)
+							mesg.Lines = ReadNumber(engine, cancellationToken);
+					}
 				} else {
 					mesg.Envelope = ParseEnvelope (engine, cancellationToken);
 					mesg.Body = ParseBody (engine, path, cancellationToken);


### PR DESCRIPTION
Hey Jeffrey,
I fetch message from GMail with MessageSummaryItems.BodyStructure flag.
GMail outputs:

" (((\"TEXT\" \"PLAIN\" (\"CHARSET\" \"koi8-r\") NIL NIL \"QUOTED-PRINTABLE\" 4452 113 NIL NIL NIL)(\"TEXT\" \"HTML\" (\"CHARSET\" \"koi8-r\") NIL NIL \"QUOTED-PRINTABLE\" 10350 240 NIL NIL NIL) \"ALTERNATIVE\" (\"BOUNDARY\" \"----=_NextPart_001_0539_01CAA4EE.0103D300\") NIL NIL)(\"MESSAGE\" \"RFC822\" (\"NAME\" \"=?KOI8-R?B?0NLF1MXO2snRIC0g9/TiMjQuZW1s?=\") NIL NIL \"7BIT\" 23379 NIL (\"ATTACHMENT\" (\"FILENAME\" \"=?KOI8-R?B?0NLF1MXO2snRIC0g9/TiMjQuZW1s?=\")) NIL) \"MIXED\" (\"BOUNDARY\" \"----=_NextPart_000_0538_01CAA4EE.0103D300\") NIL NIL))\r\n"

And MailKit throw exception while trying to parse envelope for message/rfc822 body.

My patch can help.
