### PR TITLE
Fix bug in parsing string with escape symbols in envelope.

### DIFF
--- a/MailKit/Envelope.cs
+++ b/MailKit/Envelope.cs
@@ -320,6 +320,7 @@ namespace MailKit {
 
 				if (escaped || text[index] != '\\') {
 					token.Append (text[index]);
+					escaped = false;
 				} else {
 					escaped = true;
 				}


### PR DESCRIPTION
Once escaped == true, loop breaks only if index == text.Length.
