### PR TITLE
Fix InvalidOperationException in LookupParentFolders.

### DIFF
--- a/MailKit/Net/Imap/ImapEngine.cs
+++ b/MailKit/Net/Imap/ImapEngine.cs
@@ -1536,7 +1536,9 @@ namespace MailKit.Net.Imap {
 			ImapFolder parent;
 			int index;
 
-			foreach (var folder in list) {
+			for (int i = 0; i < list.Count; i++) {
+				var folder = list[i];
+
 				if (folder.ParentFolder != null)
 					continue;
 


### PR DESCRIPTION
There is InvalidOperationException if we modify list (line: "list.Add (parent);") inside foreach( list ).
