### PR TITLE
OnCountChanged fixed to work with expunge + exists

### DIFF
--- a/MailKit/Net/Imap/ImapFolder.cs
+++ b/MailKit/Net/Imap/ImapFolder.cs
@@ -6627,6 +6627,8 @@ namespace MailKit.Net.Imap {
 
 		internal void OnExpunge (int index)
 		{
+			Count--;
+			
 			OnMessageExpunged (new MessageEventArgs (index));
 		}
 

--- a/UnitTests/Net/Imap/Resources/gmail/count.examine.txt
+++ b/UnitTests/Net/Imap/Resources/gmail/count.examine.txt
@@ -1,0 +1,8 @@
+* FLAGS (\Answered \Flagged \Draft \Deleted \Seen $Phishing $NotPhishing)
+* OK [PERMANENTFLAGS (\Answered \Flagged \Draft \Deleted \Seen $Phishing $NotPhishing \*)] Flags permitted.
+* OK [UIDVALIDITY 26] UIDs valid.
+* 1 EXISTS
+* 0 RECENT
+* OK [UIDNEXT 2] Predicted next UID.
+* OK [HIGHESTMODSEQ 29225]
+A00000005 OK [READ-WRITE] Inbox selected. (Success)

--- a/UnitTests/Net/Imap/Resources/gmail/count.noop.txt
+++ b/UnitTests/Net/Imap/Resources/gmail/count.noop.txt
@@ -1,0 +1,3 @@
+* 1 EXPUNGE
+* 1 EXISTS
+A00000006 OK NOOP completed

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -171,6 +171,8 @@
     <EmbeddedResource Include="Net\Imap\Resources\gmail\append.50.txt" />
     <EmbeddedResource Include="Net\Imap\Resources\gmail\authenticate.txt" />
     <EmbeddedResource Include="Net\Imap\Resources\gmail\capability.txt" />
+    <EmbeddedResource Include="Net\Imap\Resources\gmail\count.examine.txt" />
+    <EmbeddedResource Include="Net\Imap\Resources\gmail\count.noop.txt" />
     <EmbeddedResource Include="Net\Imap\Resources\gmail\create-unittests.txt" />
     <EmbeddedResource Include="Net\Imap\Resources\gmail\delete-unittests.txt" />
     <EmbeddedResource Include="Net\Imap\Resources\gmail\examine-inbox.txt" />


### PR DESCRIPTION
When a new email comes in after another one has been expunged the CountChanged should be triggered.This way one could use the CountChanged (EXISTS) as a real notification of a new email, as is intended by the RFC. Without having to keep track of expunges yourself. Especially useful to simplify a mailbox listener that uses IDLE, which could now use CountChanged to stop the IDLE and check any new messages.
But maybe the CountChanged event should be renamed to OnExists for this to make more sense. I would atleast like to be able to be notified of (all) the EXISTS messages. And this scenario shows that some will be ignored.
