### PR TITLE
Modified a CopyTo to MoveTo

### DIFF
--- a/MailKit/MailFolder.cs
+++ b/MailKit/MailFolder.cs
@@ -2742,7 +2742,7 @@ namespace MailKit {
 
 			return Task.Factory.StartNew (() => {
 				lock (SyncRoot) {
-					return CopyTo (uid, destination, cancellationToken);
+					return MoveTo (uid, destination, cancellationToken);
 				}
 			}, cancellationToken, TaskCreationOptions.None, TaskScheduler.Default);
 		}


### PR DESCRIPTION
Found a CopyTo() call in a MoveTo() method in MailFolder.cs that was causing me some issues.
