### PR TITLE
Fix MailService.Connect method

### DIFF
--- a/MailKit/MailService.cs
+++ b/MailKit/MailService.cs
@@ -327,7 +327,7 @@ namespace MailKit {
 				options = SecureSocketOptions.StartTlsWhenAvailable;
 			}
 
-			Connect (uri.Host, uri.Port, options, cancellationToken);
+			Connect (uri.Host, uri.Port < 0 ? 0 : uri.Port, options, cancellationToken);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Method Connect fail with ArgumentOutOfRangeException ("port")
if uri do not contains port declaration

simple test case below that works in mailkit v1.0.2 but broken in v1.0.13 
using(var client = new ImapClient()) {
	client.Connect(new Uri("imap://box.example.com"));
}