### PR TITLE
Switch constructors to protected (from internal)

### DIFF
--- a/MailKit/Net/Smtp/SmtpCommandException.cs
+++ b/MailKit/Net/Smtp/SmtpCommandException.cs
@@ -126,7 +126,7 @@ namespace MailKit.Net.Smtp {
 		/// <param name="status">The status code.</param>
 		/// <param name="mailbox">The rejected mailbox.</param>
 		/// <param name="message">The error message.</param>
-		internal SmtpCommandException (SmtpErrorCode code, SmtpStatusCode status, MailboxAddress mailbox, string message) : base (message)
+		protected SmtpCommandException (SmtpErrorCode code, SmtpStatusCode status, MailboxAddress mailbox, string message) : base (message)
 		{
 			StatusCode = (int) status;
 			Mailbox = mailbox;
@@ -142,7 +142,7 @@ namespace MailKit.Net.Smtp {
 		/// <param name="code">The error code.</param>
 		/// <param name="status">The status code.</param>>
 		/// <param name="message">The error message.</param>
-		internal SmtpCommandException (SmtpErrorCode code, SmtpStatusCode status, string message) : base (message)
+		protected SmtpCommandException (SmtpErrorCode code, SmtpStatusCode status, string message) : base (message)
 		{
 			StatusCode = (int) status;
 			ErrorCode = code;


### PR DESCRIPTION
Fixes #257 
I figured you'd rather mark these as protected than public - please advise if I'm wrong.