### PR TITLE
jstedfast/MailKit#287 changing dnxcore50 framework to dotnet5.5 platform

### DIFF
--- a/MailKit/project.json
+++ b/MailKit/project.json
@@ -9,7 +9,7 @@
   "language": "en-US",
 
   "frameworks": {
-    "dnxcore50": {
+    "dotnet5.5": {
       "compilationOptions": {
         "define": [ "COREFX" ],
         "allowUnsafe": true


### PR DESCRIPTION
Feel free to decline this pull request and do it yourself if you wish. Just wanted to show how easy it is. I tested it with the pulled down code and it seemed to work just fine. Also dotnet5.x has a 5.1 -> 5.5 range that you can choose from supporting more/less frameworks/apis. That will have to be your call. More details on that are [Here](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/standard-platform.md) except it is called .NET Platform Standard (netstandard1.x) instead of the dotnet5.x. There are more details in the issue jstedfast/MailKit#287 if you did not see that