### PR TITLE
fix Newtonsoft.Json.JsonSerializationException unable to find constru…

### DIFF
--- a/MailKit/Search/SearchQuery.cs
+++ b/MailKit/Search/SearchQuery.cs
@@ -36,6 +36,13 @@ namespace MailKit.Search {
 	/// </remarks>
 	public class SearchQuery
 	{
+        /// <summary>
+		/// public ctor
+		/// </summary>
+        public SearchQuery()
+        {
+        }
+
 		internal SearchQuery (SearchTerm term)
 		{
 			Term = term;


### PR DESCRIPTION
when deserializing mailkit searchquery (in use with hangfire job) the error "Newtonsoft.Json.JsonSerializationException cannot find default public constructor" is thrown. 
Adding the default constructor fixes the deserialization error.