### PR TITLE
Add option to ignore OfflineRevocation errors when validating certs

### DIFF
--- a/MailKit/MailService.cs
+++ b/MailKit/MailService.cs
@@ -250,93 +250,114 @@ namespace MailKit {
 		}
 
 #if !NETFX_CORE
-		/// <summary>
-		/// The default server certificate validation callback used when connecting via SSL or TLS.
-		/// </summary>
-		/// <remarks>
-		/// <para>The default server certificate validation callback considers self-signed certificates to be
-		/// valid so long as the only error in the certificate chain is an untrusted root.</para>
-		/// <note type="security">It should be noted that self-signed certificates may be an indication of
-		/// a man-in-the-middle (MITM) attack and so it is recommended that the client implement a custom
-		/// server certificate validation callback that presents the certificate to the user in some way,
-		/// allowing the user to confirm or deny its validity.</note>
-		/// </remarks>
-		/// <returns><c>true</c> if the certificate is deemed valid; otherwise, <c>false</c>.</returns>
-		/// <param name="sender">The object that is connecting via SSL or TLS.</param>
-		/// <param name="certificate">The server's SSL certificate.</param>
-		/// <param name="chain">The server's SSL certificate chain.</param>
-		/// <param name="sslPolicyErrors">The SSL policy errors.</param>
-		public static bool DefaultServerCertificateValidationCallback (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
-		{
-			if (sslPolicyErrors == SslPolicyErrors.None)
-				return true;
+        /// <summary>
+        /// Get or set whether or not X509ChainStatusFlags.OfflineRevocation errors should be ignored during server certificate validation.
+        /// </summary>
+        /// <remarks>
+        /// Gets or sets whether or not X509ChainStatusFlags.OfflineRevocation errors should be ignored during server certificate validation.
+        /// </remarks>
+        /// <value><c>true</c> if the error should be ignored; otherwise, <c>false</c>.</value>
 
-			// if there are errors in the certificate chain, look at each error to determine the cause
-			if ((sslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) != 0) {
-				if (chain != null && chain.ChainStatus != null) {
-					foreach (var status in chain.ChainStatus) {
-						if ((certificate.Subject == certificate.Issuer) && (status.Status == X509ChainStatusFlags.UntrustedRoot)) {
-							// treat self-signed certificates with an untrusted root as valid since they are so
-							// common among mail server installations
-							continue;
-						}
+        public static bool IgnoreOfflineRevocationError { get; set; }
 
-						if (status.Status != X509ChainStatusFlags.NoError) {
-							// if there are any other errors in the certificate chain, the certificate is invalid,
-							// so return false
-							return false;
-						}
-					}
-				}
+        /// <summary>
+        /// The default server certificate validation callback used when connecting via SSL or TLS.
+        /// </summary>
+        /// <remarks>
+        /// <para>The default server certificate validation callback considers self-signed certificates to be
+        /// valid so long as the only error in the certificate chain is an untrusted root.</para>
+        /// <note type="security">It should be noted that self-signed certificates may be an indication of
+        /// a man-in-the-middle (MITM) attack and so it is recommended that the client implement a custom
+        /// server certificate validation callback that presents the certificate to the user in some way,
+        /// allowing the user to confirm or deny its validity.</note>
+        /// </remarks>
+        /// <returns><c>true</c> if the certificate is deemed valid; otherwise, <c>false</c>.</returns>
+        /// <param name="sender">The object that is connecting via SSL or TLS.</param>
+        /// <param name="certificate">The server's SSL certificate.</param>
+        /// <param name="chain">The server's SSL certificate chain.</param>
+        /// <param name="sslPolicyErrors">The SSL policy errors.</param>
+        public static bool DefaultServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        {
+            if (sslPolicyErrors == SslPolicyErrors.None)
+                return true;
 
-				// Note: If we get this far, then the only errors in the certificate chain are untrusted root errors for
-				// self-signed certificates. Since self-signed certificates are so common for mail server installations,
-				// treat the certificate as valid.
-				return true;
-			}
+            // if there are errors in the certificate chain, look at each error to determine the cause
+            if ((sslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) != 0)
+            {
+                if (chain != null && chain.ChainStatus != null)
+                {
+                    foreach (var status in chain.ChainStatus)
+                    {
+                        if ((certificate.Subject == certificate.Issuer) && (status.Status == X509ChainStatusFlags.UntrustedRoot))
+                        {
+                            // treat self-signed certificates with an untrusted root as valid since they are so
+                            // common among mail server installations
+                            continue;
+                        }
 
-			return false;
-		}
+                        if ((status.Status == X509ChainStatusFlags.OfflineRevocation) && IgnoreOfflineRevocationError)
+                        {
+                            // treat certificate as valid if the online certificate revocation list (CRL) is currently offline 
+                            continue;
+                        }
+
+                        if (status.Status != X509ChainStatusFlags.NoError)
+                        {
+                            // if there are any other errors in the certificate chain, the certificate is invalid,
+                            // so return false
+                            return false;
+                        }
+                    }
+                }
+
+                // Note: If we get this far, then the only errors in the certificate chain are either untrusted root errors for
+                // self-signed certificates or offline revocation errors. Since self-signed certificates are so common for mail 
+                // server installations and CRLs can be offline, treat the certificate as valid.
+                return true;
+            }
+
+            return false;
+        }
 #endif
 
-		/// <summary>
-		/// Establish a connection to the specified mail server.
-		/// </summary>
-		/// <remarks>
-		/// Establishes a connection to the specified mail server.
-		/// </remarks>
-		/// <example>
-		/// <code language="c#" source="Examples\SmtpExamples.cs" region="SendMessage"/>
-		/// </example>
-		/// <param name="host">The host name to connect to.</param>
-		/// <param name="port">The port to connect to. If the specified port is <c>0</c>, then the default port will be used.</param>
-		/// <param name="options">The secure socket options to when connecting.</param>
-		/// <param name="cancellationToken">The cancellation token.</param>
-		/// <exception cref="System.ArgumentNullException">
-		/// <paramref name="host"/> is <c>null</c>.
-		/// </exception>
-		/// <exception cref="System.ArgumentOutOfRangeException">
-		/// <paramref name="port"/> is not between <c>0</c> and <c>65535</c>.
-		/// </exception>
-		/// <exception cref="System.ArgumentException">
-		/// The <paramref name="host"/> is a zero-length string.
-		/// </exception>
-		/// <exception cref="System.ObjectDisposedException">
-		/// The <see cref="MailService"/> has been disposed.
-		/// </exception>
-		/// <exception cref="System.InvalidOperationException">
-		/// The <see cref="MailService"/> is already connected.
-		/// </exception>
-		/// <exception cref="System.OperationCanceledException">
-		/// The operation was canceled via the cancellation token.
-		/// </exception>
-		/// <exception cref="System.IO.IOException">
-		/// An I/O error occurred.
-		/// </exception>
-		/// <exception cref="ProtocolException">
-		/// A protocol error occurred.
-		/// </exception>
-		public abstract void Connect (string host, int port = 0, SecureSocketOptions options = SecureSocketOptions.Auto, CancellationToken cancellationToken = default (CancellationToken));
+        /// <summary>
+        /// Establish a connection to the specified mail server.
+        /// </summary>
+        /// <remarks>
+        /// Establishes a connection to the specified mail server.
+        /// </remarks>
+        /// <example>
+        /// <code language="c#" source="Examples\SmtpExamples.cs" region="SendMessage"/>
+        /// </example>
+        /// <param name="host">The host name to connect to.</param>
+        /// <param name="port">The port to connect to. If the specified port is <c>0</c>, then the default port will be used.</param>
+        /// <param name="options">The secure socket options to when connecting.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// <paramref name="host"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// <paramref name="port"/> is not between <c>0</c> and <c>65535</c>.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// The <paramref name="host"/> is a zero-length string.
+        /// </exception>
+        /// <exception cref="System.ObjectDisposedException">
+        /// The <see cref="MailService"/> has been disposed.
+        /// </exception>
+        /// <exception cref="System.InvalidOperationException">
+        /// The <see cref="MailService"/> is already connected.
+        /// </exception>
+        /// <exception cref="System.OperationCanceledException">
+        /// The operation was canceled via the cancellation token.
+        /// </exception>
+        /// <exception cref="System.IO.IOException">
+        /// An I/O error occurred.
+        /// </exception>
+        /// <exception cref="ProtocolException">
+        /// A protocol error occurred.
+        /// </exception>
+        public abstract void Connect (string host, int port = 0, SecureSocketOptions options = SecureSocketOptions.Auto, CancellationToken cancellationToken = default (CancellationToken));
 
 		/// <summary>
 		/// Asynchronously establish a connection to the specified mail server.


### PR DESCRIPTION
Currently using a custom server certificate validation callback - would like to use default with IgnoreOfflineRevocationError flag if possible - hence the pull request.