### PR TITLE
Include smtp authentication error messaging when throwing AuthenticationException

### DIFF
--- a/MailKit/Net/Smtp/SmtpClient.cs
+++ b/MailKit/Net/Smtp/SmtpClient.cs
@@ -603,7 +603,7 @@ namespace MailKit.Net.Smtp {
 				throw new NotSupportedException ("The SMTP server does not support authentication.");
 
 			var uri = new Uri ("smtp://" + host);
-			SaslException authException = null;
+			Exception authException = null;
 			SmtpResponse response;
 			SaslMechanism sasl;
 			bool tried = false;
@@ -654,6 +654,9 @@ namespace MailKit.Net.Smtp {
 					authenticated = true;
 					OnAuthenticated (response.Response);
 					return;
+				}
+				else {
+					authException = new AuthenticationException(response.StatusCode + ": " + response.Response);
 				}
 			}
 


### PR DESCRIPTION
The smtp authentication error response returned from the smtp server often contains useful information about what went wrong and how to fix it. 

For example, when using a bad username/pass with gmail, the AuthenticationException message now contains:

> AuthenticationInvalidCredentials: 5.7.8 Username and Password not accepted. Learn more at
> 5.7.8  https://support.google.com/mail/?p=BadCredentials l187sm13726105pfc.0 - gsmtp

We use this messaging to showing our users a useful error dialog. 