### PR TITLE
Workaround for SendCloud SMTP server

### DIFF
--- a/MailKit/Net/Smtp/SmtpClient.cs
+++ b/MailKit/Net/Smtp/SmtpClient.cs
@@ -470,7 +470,10 @@ namespace MailKit.Net.Smtp {
 			if (authenticated && response.StatusCode == SmtpStatusCode.BadCommandSequence)
 				return;
 
-			if (response.StatusCode != SmtpStatusCode.Ok) {
+            if (response.Response == "You already said EHLO")
+                return;
+
+            if (response.StatusCode != SmtpStatusCode.Ok) {
 				// Try sending HELO instead...
 				response = SendEhlo (false, cancellationToken);
 				if (response.StatusCode != SmtpStatusCode.Ok)


### PR DESCRIPTION
This PR is to fix the following exception when using MailKit with SendCloud SMTP server (smtp.sendcloud.net).

>MailKit.Net.Smtp.SmtpCommandException: You already said HELO
>   at MailKit.Net.Smtp.SmtpClient.Ehlo(CancellationToken cancellationToken)
>   at MailKit.Net.Smtp.SmtpClient.Authenticate(Encoding encoding, ICredentials credentials, CancellationToken cancellationToken)