### PR TITLE
Compiling with XBuild

### DIFF
--- a/MailKit/Net/Pop3/Pop3Stream.cs
+++ b/MailKit/Net/Pop3/Pop3Stream.cs
@@ -606,7 +606,11 @@ namespace MailKit.Net.Pop3 {
 					while (*inptr != (byte) '\n')
 						inptr++;
 
-					inputIndex = (int) (inptr - inbuf);
+					// Compiling on Linux with XBuild generated a "Not implemented exception".
+					// The use of this temp variable fixes this.
+					int inputIndexTmp = (int) (inptr - inbuf);
+					inputIndex = inputIndexTmp;
+					//inputIndex = (int) (inptr - inbuf);
 					count = (int) (inptr - start);
 
 					if (inptr == inend) {


### PR DESCRIPTION
Compiling on Linux with XBuild generates a "Not implemented exception".
The use of a temp variable fixes that.