### PR TITLE
Modified ProtocolLogger log-to-file constructor to support Shared Read and append/overwrite option

### DIFF
--- a/MailKit/ProtocolLogger.cs
+++ b/MailKit/ProtocolLogger.cs
@@ -57,17 +57,13 @@ namespace MailKit {
 		/// Initializes a new instance of the <see cref="MailKit.ProtocolLogger"/> class.
 		/// </summary>
 		/// <remarks>
-		/// Creates a new <see cref="ProtocolLogger"/> to log to a specified file. File is created if it does not exist.
+		/// Creates a new <see cref="ProtocolLogger"/> to log to a specified file. The file is created if it does not exist.
 		/// </remarks>
 		/// <param name="fileName">The file name.</param>
-		/// <param name="append">If <c>true</c>, existing file is appended to. If <c>false</c>, existing file is overwritten. Defaults to <c>true</c>.</param>
+		/// <param name="append"><c>true</c> if the file should be appended to; otherwise, <c>false</c>. Defaults to <c>true</c>.</param>
 		public ProtocolLogger (string fileName, bool append = true)
 		{
-			stream = File.Open(
-				fileName, 
-				append ? FileMode.Append : FileMode.Create, 
-				FileAccess.Write, 
-				FileShare.Read);
+			stream = File.Open (fileName, append ? FileMode.Append : FileMode.Create, FileAccess.Write, FileShare.Read);
 		}
 #endif
 

--- a/MailKit/ProtocolLogger.cs
+++ b/MailKit/ProtocolLogger.cs
@@ -57,12 +57,17 @@ namespace MailKit {
 		/// Initializes a new instance of the <see cref="MailKit.ProtocolLogger"/> class.
 		/// </summary>
 		/// <remarks>
-		/// Creates a new <see cref="ProtocolLogger"/> to log to a specified file.
+		/// Creates a new <see cref="ProtocolLogger"/> to log to a specified file. File is created if it does not exist.
 		/// </remarks>
 		/// <param name="fileName">The file name.</param>
-		public ProtocolLogger (string fileName)
+		/// <param name="append">If <c>true</c>, existing file is appended to. If <c>false</c>, existing file is overwritten. Defaults to <c>true</c>.</param>
+		public ProtocolLogger (string fileName, bool append = true)
 		{
-			stream = File.OpenWrite (fileName);
+			stream = File.Open(
+				fileName, 
+				append ? FileMode.Append : FileMode.Create, 
+				FileAccess.Write, 
+				FileShare.Read);
 		}
 #endif
 


### PR DESCRIPTION
The existing constructor for directing ProtocolLogger to a file, opened the file with an exclusive lock. This prevents even read access to the file while open by MailKit, and hence prevents Tailing the file while performing operations. 

Modified the constructor to open the file in a shared read mode.

Also added an option to Append or Overwrite the file. The existing behavior is a bit odd, with File.OpenWrite causing the file to be overwritten from the beginning, but not truncated. The new behavior defaults to Append.