### PR TITLE
Fetch all headers for a list of messages

### DIFF
--- a/MailKit/Net/Imap/ImapFolderFetch.cs
+++ b/MailKit/Net/Imap/ImapFolderFetch.cs
@@ -443,37 +443,32 @@ namespace MailKit.Net.Imap
 			}
 
 			if ((items & MessageSummaryItems.References) != 0 || fields != null) {
-			    if (fields?.Count == 0)
-			    {
-			        tokens.Add("BODY.PEEK[HEADER]");
-			    }
-			    else
-			    {
-			        var headers = new StringBuilder("BODY.PEEK[HEADER.FIELDS (");
-			        bool references = false;
+				if (fields?.Count == 0)
+					tokens.Add ("BODY.PEEK[HEADER]");
+				else {
+					var headers = new StringBuilder ("BODY.PEEK[HEADER.FIELDS (");
+					bool references = false;
 
-			        if (fields != null)
-			        {
-			            foreach (var field in fields)
-			            {
-			                var name = field.ToUpperInvariant();
+					if (fields != null) {
+						foreach (var field in fields) {
+							var name = field.ToUpperInvariant ();
 
-			                if (name == "REFERENCES")
-			                    references = true;
+							if (name == "REFERENCES")
+								references = true;
 
-			                headers.Append(name);
-			                headers.Append(' ');
-			            }
-			        }
+							headers.Append (name);
+							headers.Append (' ');
+						}
+					}
 
-			        if ((items & MessageSummaryItems.References) != 0 && !references)
-			            headers.Append("REFERENCES ");
+ 					if ((items & MessageSummaryItems.References) != 0 && !references)
+						headers.Append ("REFERENCES ");
 
-			        headers[headers.Length - 1] = ')';
-			        headers.Append(']');
+					headers[headers.Length - 1] = ')';
+					headers.Append (']');
 
-			        tokens.Add(headers.ToString());
-                }
+					tokens.Add (headers.ToString ());
+				}
 			}
 
 			if (tokens.Count == 1)
@@ -681,8 +676,6 @@ namespace MailKit.Net.Imap
 			if (fields == null)
 				throw new ArgumentNullException (nameof (fields));
 
-			//if (fields.Count == 0)
-			//	throw new ArgumentException ("The set of header fields cannot be empty.", nameof (fields));
 
 			CheckState (true, false);
 

--- a/MailKit/Net/Imap/ImapFolderFetch.cs
+++ b/MailKit/Net/Imap/ImapFolderFetch.cs
@@ -443,28 +443,37 @@ namespace MailKit.Net.Imap
 			}
 
 			if ((items & MessageSummaryItems.References) != 0 || fields != null) {
-				var headers = new StringBuilder ("BODY.PEEK[HEADER.FIELDS (");
-				bool references = false;
+			    if (fields?.Count == 0)
+			    {
+			        tokens.Add("BODY.PEEK[HEADER]");
+			    }
+			    else
+			    {
+			        var headers = new StringBuilder("BODY.PEEK[HEADER.FIELDS (");
+			        bool references = false;
 
-				if (fields != null) {
-					foreach (var field in fields) {
-						var name = field.ToUpperInvariant ();
+			        if (fields != null)
+			        {
+			            foreach (var field in fields)
+			            {
+			                var name = field.ToUpperInvariant();
 
-						if (name == "REFERENCES")
-							references = true;
+			                if (name == "REFERENCES")
+			                    references = true;
 
-						headers.Append (name);
-						headers.Append (' ');
-					}
-				}
+			                headers.Append(name);
+			                headers.Append(' ');
+			            }
+			        }
 
-				if ((items & MessageSummaryItems.References) != 0 && !references)
-					headers.Append ("REFERENCES ");
+			        if ((items & MessageSummaryItems.References) != 0 && !references)
+			            headers.Append("REFERENCES ");
 
-				headers[headers.Length - 1] = ')';
-				headers.Append (']');
+			        headers[headers.Length - 1] = ')';
+			        headers.Append(']');
 
-				tokens.Add (headers.ToString ());
+			        tokens.Add(headers.ToString());
+                }
 			}
 
 			if (tokens.Count == 1)
@@ -672,8 +681,8 @@ namespace MailKit.Net.Imap
 			if (fields == null)
 				throw new ArgumentNullException (nameof (fields));
 
-			if (fields.Count == 0)
-				throw new ArgumentException ("The set of header fields cannot be empty.", nameof (fields));
+			//if (fields.Count == 0)
+			//	throw new ArgumentException ("The set of header fields cannot be empty.", nameof (fields));
 
 			CheckState (true, false);
 


### PR DESCRIPTION
Hi, 

On the ImapFolderFetch.cs:

I've added the ability to fetch all headers for a list of UniqueId.
In order to do so, I remove the check on the length of fields HashSet and modified the tokens to fetch all headers in case the hashset is non null and empty.
I didn't want to change the API but maybe you'll feel that adding a new overload of Fetch methods is more appropriate. 
Regards,

Fabien