### PR TITLE
Allow handling smtp status code SyntaxError for invalid recipient addresses.

### DIFF
--- a/MailKit/Net/Smtp/SmtpClient.cs
+++ b/MailKit/Net/Smtp/SmtpClient.cs
@@ -1718,6 +1718,7 @@ namespace MailKit.Net.Smtp {
 			case SmtpStatusCode.MailboxNameNotAllowed:
 			case SmtpStatusCode.MailboxUnavailable:
 			case SmtpStatusCode.MailboxBusy:
+			case SmtpStatusCode.SyntaxError:
 				OnRecipientNotAccepted (message, mailbox, response);
 				return false;
 			case SmtpStatusCode.AuthenticationRequired:


### PR DESCRIPTION
When sending email with multiple recipients and one or more recipient addresses are not accepted by server the whole email is aborted. In my case it was email with lots of BCC recipients where one of them had invalid email address, the whole email was not delivered.

This PR adds the `SmtpStatusCode.SyntaxError` case to `ProcessRcptToResponse` and allows the `OnRecipientNotAccepted` to handle the error.