### PR TITLE
break out WaitForNewMessagesAsync()

### DIFF
--- a/samples/ImapIdle/ImapIdle/IdleClient.cs
+++ b/samples/ImapIdle/ImapIdle/IdleClient.cs
@@ -103,6 +103,7 @@ namespace ImapIdle
 
 								// throw OperationCanceledException if the cancel token has been canceled.
 								cancel.Token.ThrowIfCancellationRequested ();
+								break;
 							}
 						}
 					} else {
@@ -110,6 +111,7 @@ namespace ImapIdle
 						// between each NOOP command.
 						await Task.Delay (new TimeSpan (0, 1, 0), cancel.Token);
 						await client.NoOpAsync (cancel.Token);
+						break;
 					}
 				} catch (ImapProtocolException) {
 					// protocol exceptions often result in the client getting disconnected


### PR DESCRIPTION
Not breaking out causes the IdleAsync to never fetch new messages (when applicable) after a the token 'expired' or cancelled.