### PR TITLE
Fixed ImapIdle example code

### DIFF
--- a/Documentation/Examples/ImapIdleExample.cs
+++ b/Documentation/Examples/ImapIdleExample.cs
@@ -41,7 +41,7 @@ namespace ImapIdleExample {
 	class IdleClient : IDisposable
 	{
 		readonly string host, username, password;
-		readonly SecureSocketOptions options;
+		readonly SecureSocketOptions sslOptions;
 		readonly int port;
 		List<IMessageSummary> messages;
 		CancellationTokenSource cancel;


### PR DESCRIPTION
readonly SecureSocketOptions options was not used, whilst constructor was referring to a non existing Ssloptions.
I believe you would want these to reference eachother.