### PR TITLE
Consider 200 OK with empty body as a successful connection

### DIFF
--- a/MailKit/Net/Proxy/HttpProxyClient.cs
+++ b/MailKit/Net/Proxy/HttpProxyClient.cs
@@ -160,7 +160,7 @@ namespace MailKit.Net.Proxy
 
 				var response = builder.ToString ();
 
-				if (response.Length >= 16 && response.StartsWith ("HTTP/1.", StringComparison.OrdinalIgnoreCase) &&
+				if (response.Length >= 15 && response.StartsWith ("HTTP/1.", StringComparison.OrdinalIgnoreCase) &&
 					(response[7] == '1' || response[7] == '0') && response[8] == ' ' &&
 					response[9] == '2' && response[10] == '0' && response[11] == '0' &&
 					response[12] == ' ') {


### PR DESCRIPTION
Hello, thanks for your awesome library! However, I've encountered a strange behaviour, which occurs when I use specific http proxies for connecting to IMAP server:
```
MailKit.Net.Proxy.ProxyProtocolException: Failed to connect to imap.rambler.ru:993: HTTP/1.1 200 OK
   at MailKit.Net.Proxy.HttpProxyClient.ConnectAsync(String host, Int32 port, Boolean doAsync, CancellationToken cancellationToken)
   at MailKit.Net.Proxy.ProxyClient.ConnectAsync(String host, Int32 port, Int32 timeout, CancellationToken cancellationToken)
   at MailKit.MailService.ConnectSocket(String host, Int32 port, Boolean doAsync, CancellationToken cancellationToken)
   at MailKit.Net.Imap.ImapClient.ConnectAsync(String host, Int32 port, SecureSocketOptions options, Boolean doAsync, CancellationToken cancellationToken)
```

The server has responded with 200 OK, however there is no payload or body at all (which apparentely is not allowed by RFC), and it is considered as an invalid response by MailKit. This pull request makes such response to be allowed.