### PR TITLE
Fix protocol violation in SOCKS5 authentication procedure

### DIFF
--- a/MailKit/Net/Proxy/Socks5Client.cs
+++ b/MailKit/Net/Proxy/Socks5Client.cs
@@ -229,8 +229,6 @@ namespace MailKit.Net.Proxy
 					n += nread;
 			} while (n < 2);
 
-			VerifySocksVersion (buffer[0]);
-
 			if (buffer[1] != (byte) Socks5Reply.Success)
 				throw new AuthenticationException ("Failed to authenticate with SOCKS5 proxy server.");
 		}

--- a/MailKit/Net/Proxy/Socks5Client.cs
+++ b/MailKit/Net/Proxy/Socks5Client.cs
@@ -211,7 +211,7 @@ namespace MailKit.Net.Proxy
 			var buffer = new byte[user.Length + passwd.Length + 3];
 			int nread, n = 0;
 
-			buffer[n++] = (byte) SocksVersion;
+			buffer[n++] = 1;
 			buffer[n++] = (byte) user.Length;
 			Buffer.BlockCopy (user, 0, buffer, n, user.Length);
 			n += user.Length;


### PR DESCRIPTION
MailKit sends an invalid authentication request, which leads to disconnection from proxy server.
Due to [RFC1929](https://tools.ietf.org/html/rfc1929), during authentication `VER` field should always equal to `1`:

> The VER field contains the current version of the subnegotiation, which is X'01'.

However, Socks5Client sends a protocol version, which is `5`.