### PR TITLE
Remove redundant .NET Standard 2.0 package references

### DIFF
--- a/MailKit/MailKit.csproj
+++ b/MailKit/MailKit.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>An Open Source cross-platform .NET mail-client library that is based on MimeKit and optimized for mobile devices.</Description>
@@ -37,11 +37,11 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <DefineConstants>$(DefineConstants);SERIALIZABLE</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion)' != 'v2.0' ">
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />

--- a/MailKit/MailService.cs
+++ b/MailKit/MailService.cs
@@ -52,7 +52,7 @@ namespace MailKit {
 #if NET48
 		const SslProtocols DefaultSslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13;
 #else
-		const SslProtocols DefaultSslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12;
+		const SslProtocols DefaultSslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12 | (SslProtocols) 12288;
 #endif
 
 		/// <summary>

--- a/nuget/MailKit.nuspec
+++ b/nuget/MailKit.nuspec
@@ -99,9 +99,6 @@ client.Authenticate (new SaslMechanismOAuth2 (username, auth_token));
         <dependency id="MimeKit" version="2.9.1" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="System.Runtime.Serialization.Primitives" version="4.3.0" />
-        <dependency id="System.Net.NameResolution" version="4.3.0" />
-        <dependency id="System.Net.Security" version="4.3.2" />
         <dependency id="MimeKit" version="2.9.1" />
       </group>
     </dependencies>


### PR DESCRIPTION
And add support for TLS 1.3 in frameworks other than .NET Framework 4.8.