### PR TITLE
feat: Add ProtocolLogger for Microsoft Extension Logging

### DIFF
--- a/MailKit/Logging/IProtocolLogger.cs
+++ b/MailKit/Logging/IProtocolLogger.cs
@@ -26,7 +26,7 @@
 
 using System;
 
-namespace MailKit {
+namespace MailKit.Logging {
 	/// <summary>
 	/// An interface for logging the communication between a client and server.
 	/// </summary>
@@ -36,7 +36,7 @@ namespace MailKit {
 	/// <example>
 	/// <code language="c#" source="Examples\SmtpExamples.cs" region="ProtocolLogger" />
 	/// </example>
-	public interface IProtocolLogger : IDisposable
+	public interface IProtocolLogger
 	{
 		/// <summary>
 		/// Logs a connection to the specified URI.

--- a/MailKit/Logging/NullProtocolLogger.cs
+++ b/MailKit/Logging/NullProtocolLogger.cs
@@ -26,7 +26,7 @@
 
 using System;
 
-namespace MailKit {
+namespace MailKit.Logging {
 	/// <summary>
 	/// A protocol logger that does not log to anywhere.
 	/// </summary>
@@ -39,7 +39,7 @@ namespace MailKit {
 	public sealed class NullProtocolLogger : IProtocolLogger
 	{
 		/// <summary>
-		/// Initializes a new instance of the <see cref="MailKit.NullProtocolLogger"/> class.
+		/// Initializes a new instance of the <see cref="NullProtocolLogger"/> class.
 		/// </summary>
 		/// <remarks>
 		/// Creates a new <see cref="NullProtocolLogger"/>.
@@ -90,21 +90,6 @@ namespace MailKit {
 		/// <paramref name="buffer"/> is <c>null</c>.
 		/// </exception>
 		public void LogServer (byte[] buffer, int offset, int count)
-		{
-		}
-
-		#endregion
-
-		#region IDisposable implementation
-
-		/// <summary>
-		/// Releases all resource used by the <see cref="MailKit.NullProtocolLogger"/> object.
-		/// </summary>
-		/// <remarks>Call <see cref="Dispose"/> when you are finished using the <see cref="MailKit.NullProtocolLogger"/>. The
-		/// <see cref="Dispose"/> method leaves the <see cref="MailKit.NullProtocolLogger"/> in an unusable state. After
-		/// calling <see cref="Dispose"/>, you must release all references to the <see cref="MailKit.NullProtocolLogger"/> so
-		/// the garbage collector can reclaim the memory that the <see cref="MailKit.NullProtocolLogger"/> was occupying.</remarks>
-		public void Dispose ()
 		{
 		}
 

--- a/MailKit/Logging/ProtocolLogger.cs
+++ b/MailKit/Logging/ProtocolLogger.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace MailKit.Logging
+{
+	/// <inheritdoc />
+	public class ProtocolLogger : IProtocolLogger
+	{
+		private readonly ILogger<ProtocolLogger> _logger;
+
+		/// <summary>
+		/// Log messages via Microsoft Extension Logging (MEL) Microsoft ILogger <see cref="ILogger"/>.
+		/// </summary>
+		/// <remarks>
+		/// For more information how configure it see example in <seealso cref="https://github.com/NLog/NLog/wiki/Getting-started-with-.NET-Core-2---Console-application"/>
+		/// </remarks>
+		/// <param name="logger">The logger that resolves through Dependency injector (DI)</param>
+		public ProtocolLogger (ILogger<ProtocolLogger> logger)
+		{
+			_logger = logger;
+		}
+
+		/// <inheritdoc />
+		public void LogConnect (Uri uri)
+		{
+			if (uri == null)
+				throw new ArgumentNullException (nameof (uri));
+
+			_logger.Log (LogLevel.Trace, $"Connected to {uri}");
+		}
+
+		/// <inheritdoc />
+		public void LogClient (byte[] buffer, int offset, int count)
+		{
+			var message = Encoding.UTF8
+				.GetString (buffer)
+				.TrimEnd ('\0')
+				.Replace (Environment.NewLine, string.Empty);
+
+			_logger.Log (LogLevel.Trace, $"Client: {message}");
+		}
+
+		/// <inheritdoc />
+		public void LogServer (byte[] buffer, int offset, int count)
+		{
+			var message = Encoding.UTF8
+				.GetString (buffer)
+				.TrimEnd ('\0')
+				.Replace (Environment.NewLine, string.Empty);
+
+			_logger.Log (LogLevel.Trace, $"Server: {message}");
+		}
+	}
+}

--- a/MailKit/Logging/ProtocolStreamLogger.cs
+++ b/MailKit/Logging/ProtocolStreamLogger.cs
@@ -28,7 +28,7 @@ using System;
 using System.IO;
 using System.Text;
 
-namespace MailKit {
+namespace MailKit.Logging {
 	/// <summary>
 	/// A default protocol logger for logging the communication between a client and server.
 	/// </summary>
@@ -38,7 +38,7 @@ namespace MailKit {
 	/// <example>
 	/// <code language="c#" source="Examples\SmtpExamples.cs" region="ProtocolLogger" />
 	/// </example>
-	public class ProtocolLogger : IProtocolLogger
+	public class ProtocolStreamLogger : IProtocolLogger, IDisposable
 	{
 		static byte[] defaultClientPrefix = Encoding.ASCII.GetBytes ("C: ");
 		static byte[] defaultServerPrefix = Encoding.ASCII.GetBytes ("S: ");
@@ -51,30 +51,30 @@ namespace MailKit {
 		bool serverMidline;
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="MailKit.ProtocolLogger"/> class.
+		/// Initializes a new instance of the <see cref="ProtocolStreamLogger"/> class.
 		/// </summary>
 		/// <remarks>
-		/// Creates a new <see cref="ProtocolLogger"/> to log to a specified file. The file is created if it does not exist.
+		/// Creates a new <see cref="ProtocolStreamLogger"/> to log to a specified file. The file is created if it does not exist.
 		/// </remarks>
 		/// <example>
 		/// <code language="c#" source="Examples\SmtpExamples.cs" region="ProtocolLogger" />
 		/// </example>
 		/// <param name="fileName">The file name.</param>
 		/// <param name="append"><c>true</c> if the file should be appended to; otherwise, <c>false</c>. Defaults to <c>true</c>.</param>
-		public ProtocolLogger (string fileName, bool append = true)
+		public ProtocolStreamLogger (string fileName, bool append = true)
 		{
 			stream = File.Open (fileName, append ? FileMode.Append : FileMode.Create, FileAccess.Write, FileShare.Read);
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="MailKit.ProtocolLogger"/> class.
+		/// Initializes a new instance of the <see cref="ProtocolStreamLogger"/> class.
 		/// </summary>
 		/// <remarks>
-		/// Creates a new <see cref="ProtocolLogger"/> to log to a specified stream.
+		/// Creates a new <see cref="ProtocolStreamLogger"/> to log to a specified stream.
 		/// </remarks>
 		/// <param name="stream">The stream.</param>
 		/// <param name="leaveOpen"><c>true</c> if the stream should be left open after the protocol logger is disposed.</param>
-		public ProtocolLogger (Stream stream, bool leaveOpen = false)
+		public ProtocolStreamLogger (Stream stream, bool leaveOpen = false)
 		{
 			if (stream == null)
 				throw new ArgumentNullException (nameof (stream));
@@ -84,14 +84,14 @@ namespace MailKit {
 		}
 
 		/// <summary>
-		/// Releases unmanaged resources and performs other cleanup operations before the <see cref="MailKit.ProtocolLogger"/>
+		/// Releases unmanaged resources and performs other cleanup operations before the <see cref="ProtocolStreamLogger"/>
 		/// is reclaimed by garbage collection.
 		/// </summary>
 		/// <remarks>
-		/// Releases unmanaged resources and performs other cleanup operations before the <see cref="MailKit.ProtocolLogger"/>
+		/// Releases unmanaged resources and performs other cleanup operations before the <see cref="ProtocolStreamLogger"/>
 		/// is reclaimed by garbage collection.
 		/// </remarks>
-		~ProtocolLogger ()
+		~ProtocolStreamLogger ()
 		{
 			Dispose (false);
 		}
@@ -108,10 +108,10 @@ namespace MailKit {
 		}
 
 		/// <summary>
-		/// Get or set the default client prefix to use when creating new <see cref="MailKit.ProtocolLogger"/> instances.
+		/// Get or set the default client prefix to use when creating new <see cref="ProtocolStreamLogger"/> instances.
 		/// </summary>
 		/// <remarks>
-		/// Get or set the default client prefix to use when creating new <see cref="MailKit.ProtocolLogger"/> instances.
+		/// Get or set the default client prefix to use when creating new <see cref="ProtocolStreamLogger"/> instances.
 		/// </remarks>
 		/// <value>The default client prefix.</value>
 		public static string DefaultClientPrefix
@@ -121,10 +121,10 @@ namespace MailKit {
 		}
 
 		/// <summary>
-		/// Get or set the default server prefix to use when creating new <see cref="MailKit.ProtocolLogger"/> instances.
+		/// Get or set the default server prefix to use when creating new <see cref="ProtocolStreamLogger"/> instances.
 		/// </summary>
 		/// <remarks>
-		/// Get or set the default server prefix to use when creating new <see cref="MailKit.ProtocolLogger"/> instances.
+		/// Get or set the default server prefix to use when creating new <see cref="ProtocolStreamLogger"/> instances.
 		/// </remarks>
 		/// <value>The default server prefix.</value>
 		public static string DefaultServerPrefix
@@ -308,11 +308,11 @@ namespace MailKit {
 		#region IDisposable implementation
 
 		/// <summary>
-		/// Releases the unmanaged resources used by the <see cref="ProtocolLogger"/> and
+		/// Releases the unmanaged resources used by the <see cref="ProtocolStreamLogger"/> and
 		/// optionally releases the managed resources.
 		/// </summary>
 		/// <remarks>
-		/// Releases the unmanaged resources used by the <see cref="ProtocolLogger"/> and
+		/// Releases the unmanaged resources used by the <see cref="ProtocolStreamLogger"/> and
 		/// optionally releases the managed resources.
 		/// </remarks>
 		/// <param name="disposing"><c>true</c> to release both managed and unmanaged resources;
@@ -324,12 +324,12 @@ namespace MailKit {
 		}
 
 		/// <summary>
-		/// Releases all resource used by the <see cref="MailKit.ProtocolLogger"/> object.
+		/// Releases all resource used by the <see cref="ProtocolStreamLogger"/> object.
 		/// </summary>
-		/// <remarks>Call <see cref="Dispose()"/> when you are finished using the <see cref="MailKit.ProtocolLogger"/>. The
-		/// <see cref="Dispose()"/> method leaves the <see cref="MailKit.ProtocolLogger"/> in an unusable state. After calling
-		/// <see cref="Dispose()"/>, you must release all references to the <see cref="MailKit.ProtocolLogger"/> so the garbage
-		/// collector can reclaim the memory that the <see cref="MailKit.ProtocolLogger"/> was occupying.</remarks>
+		/// <remarks>Call <see cref="Dispose()"/> when you are finished using the <see cref="ProtocolStreamLogger"/>. The
+		/// <see cref="Dispose()"/> method leaves the <see cref="ProtocolStreamLogger"/> in an unusable state. After calling
+		/// <see cref="Dispose()"/>, you must release all references to the <see cref="ProtocolStreamLogger"/> so the garbage
+		/// collector can reclaim the memory that the <see cref="ProtocolStreamLogger"/> was occupying.</remarks>
 		public void Dispose ()
 		{
 			Dispose (true);

--- a/MailKit/MailKit.csproj
+++ b/MailKit/MailKit.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>MailKit</AssemblyTitle>
     <VersionPrefix>2.10.1</VersionPrefix>
     <Authors>Jeffrey Stedfast</Authors>
-    <TargetFrameworks>netstandard2.0;net45;net46;net47;net48;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net47;net48;net50</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AssemblyName>MailKit</AssemblyName>
@@ -111,6 +111,7 @@
     <Compile Include="Net\SocketUtils.cs" />
     <Compile Include="Net\SslStream.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Logging\ProtocolLogger.cs" />
     <Compile Include="Search\AnnotationSearchQuery.cs" />
     <Compile Include="Search\BinarySearchQuery.cs" />
     <Compile Include="Search\DateSearchQuery.cs" />
@@ -200,7 +201,7 @@
     <Compile Include="IMailStore.cs" />
     <Compile Include="IMailTransport.cs" />
     <Compile Include="IMessageSummary.cs" />
-    <Compile Include="IProtocolLogger.cs" />
+    <Compile Include="Logging\IProtocolLogger.cs" />
     <Compile Include="ITransferProgress.cs" />
     <Compile Include="MailFolder.cs" />
     <Compile Include="MailService.cs" />
@@ -226,10 +227,10 @@
     <Compile Include="MetadataOptions.cs" />
     <Compile Include="MetadataTag.cs" />
     <Compile Include="ModSeqChangedEventArgs.cs" />
-    <Compile Include="NullProtocolLogger.cs" />
+    <Compile Include="Logging\NullProtocolLogger.cs" />
     <Compile Include="ProgressStream.cs" />
     <Compile Include="ProtocolException.cs" />
-    <Compile Include="ProtocolLogger.cs" />
+    <Compile Include="Logging\ProtocolStreamLogger.cs" />
     <Compile Include="ServiceNotAuthenticatedException.cs" />
     <Compile Include="ServiceNotConnectedException.cs" />
     <Compile Include="SpecialFolder.cs" />
@@ -242,4 +243,27 @@
     <Compile Include="UriExtensions.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net50'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/MailKit/MailService.cs
+++ b/MailKit/MailService.cs
@@ -39,6 +39,7 @@ using SslProtocols = System.Security.Authentication.SslProtocols;
 using MailKit.Net;
 using MailKit.Net.Proxy;
 using MailKit.Security;
+using MailKit.Logging;
 
 namespace MailKit {
 	/// <summary>
@@ -1606,8 +1607,8 @@ namespace MailKit {
 		/// <c>false</c> to release only the unmanaged resources.</param>
 		protected virtual void Dispose (bool disposing)
 		{
-			if (disposing)
-				ProtocolLogger.Dispose ();
+			if (disposing && ProtocolLogger is ProtocolStreamLogger protocolLogger)
+				protocolLogger.Dispose ();
 		}
 
 		/// <summary>

--- a/MailKit/MailSpool.cs
+++ b/MailKit/MailSpool.cs
@@ -30,7 +30,7 @@ using System.Threading;
 using System.Collections;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-
+using MailKit.Logging;
 using MimeKit;
 
 namespace MailKit {

--- a/MailKit/MailStore.cs
+++ b/MailKit/MailStore.cs
@@ -28,6 +28,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using MailKit.Logging;
 
 namespace MailKit {
 	/// <summary>

--- a/MailKit/MailTransport.cs
+++ b/MailKit/MailTransport.cs
@@ -28,7 +28,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-
+using MailKit.Logging;
 using MimeKit;
 
 namespace MailKit {

--- a/MailKit/Net/Imap/ImapClient.cs
+++ b/MailKit/Net/Imap/ImapClient.cs
@@ -36,6 +36,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 
+using MailKit.Logging;
 using MailKit.Security;
 
 using SslStream = MailKit.Net.SslStream;

--- a/MailKit/Net/Imap/ImapStream.cs
+++ b/MailKit/Net/Imap/ImapStream.cs
@@ -32,6 +32,7 @@ using System.Net.Sockets;
 using System.Globalization;
 using System.Threading.Tasks;
 
+using MailKit.Logging;
 using MimeKit.IO;
 
 using Buffer = System.Buffer;

--- a/MailKit/Net/Pop3/Pop3Client.cs
+++ b/MailKit/Net/Pop3/Pop3Client.cs
@@ -42,6 +42,7 @@ using System.Security.Cryptography.X509Certificates;
 using MimeKit;
 using MimeKit.IO;
 
+using MailKit.Logging;
 using MailKit.Security;
 
 using SslStream = MailKit.Net.SslStream;

--- a/MailKit/Net/Pop3/Pop3Stream.cs
+++ b/MailKit/Net/Pop3/Pop3Stream.cs
@@ -30,6 +30,8 @@ using System.Threading;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
+using MailKit.Logging;
+
 using MimeKit.IO;
 
 using Buffer = System.Buffer;

--- a/MailKit/Net/Smtp/SmtpClient.cs
+++ b/MailKit/Net/Smtp/SmtpClient.cs
@@ -42,6 +42,7 @@ using MimeKit.IO;
 using MimeKit.Cryptography;
 
 using MailKit.Security;
+using MailKit.Logging;
 
 using SslStream = MailKit.Net.SslStream;
 using NetworkStream = MailKit.Net.NetworkStream;

--- a/MailKit/Net/Smtp/SmtpStream.cs
+++ b/MailKit/Net/Smtp/SmtpStream.cs
@@ -32,6 +32,8 @@ using System.Net.Sockets;
 using System.Net.Security;
 using System.Threading.Tasks;
 
+using MailKit.Logging;
+
 using MimeKit.IO;
 
 using Buffer = System.Buffer;

--- a/UnitTests/Net/Imap/ImapEngineTests.cs
+++ b/UnitTests/Net/Imap/ImapEngineTests.cs
@@ -33,6 +33,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 
 using MailKit;
+using MailKit.Logging;
 using MailKit.Net.Imap;
 
 namespace UnitTests.Net.Imap {

--- a/UnitTests/Net/Imap/ImapStreamTests.cs
+++ b/UnitTests/Net/Imap/ImapStreamTests.cs
@@ -34,6 +34,7 @@ using System.Security.Cryptography;
 using NUnit.Framework;
 
 using MailKit;
+using MailKit.Logging;
 using MailKit.Net.Imap;
 
 namespace UnitTests.Net.Imap {

--- a/UnitTests/Net/Imap/ImapUtilsTests.cs
+++ b/UnitTests/Net/Imap/ImapUtilsTests.cs
@@ -38,6 +38,7 @@ using MimeKit.Utils;
 
 using MailKit.Net.Imap;
 using MailKit;
+using MailKit.Logging;
 
 namespace UnitTests.Net.Imap {
 	[TestFixture]

--- a/UnitTests/Net/Pop3/Pop3StreamTests.cs
+++ b/UnitTests/Net/Pop3/Pop3StreamTests.cs
@@ -34,6 +34,7 @@ using System.Security.Cryptography;
 using NUnit.Framework;
 
 using MailKit;
+using MailKit.Logging;
 using MailKit.Net.Pop3;
 
 namespace UnitTests.Net.Pop3 {

--- a/UnitTests/Net/Smtp/SmtpStreamTests.cs
+++ b/UnitTests/Net/Smtp/SmtpStreamTests.cs
@@ -34,6 +34,7 @@ using System.Security.Cryptography;
 using NUnit.Framework;
 
 using MailKit;
+using MailKit.Logging;
 using MailKit.Net.Smtp;
 
 namespace UnitTests.Net.Smtp {

--- a/UnitTests/ProtocolLoggerTests.cs
+++ b/UnitTests/ProtocolLoggerTests.cs
@@ -33,7 +33,7 @@ using NUnit.Framework;
 using MimeKit.IO;
 using MimeKit.IO.Filters;
 
-using MailKit;
+using MailKit.Logging;
 
 namespace UnitTests {
 	[TestFixture]
@@ -42,9 +42,9 @@ namespace UnitTests {
 		[Test]
 		public void TestArgumentExceptions ()
 		{
-			Assert.Throws<ArgumentNullException> (() => new ProtocolLogger ((string) null));
-			Assert.Throws<ArgumentNullException> (() => new ProtocolLogger ((Stream) null));
-			using (var logger = new ProtocolLogger (new MemoryStream ())) {
+			Assert.Throws<ArgumentNullException> (() => new ProtocolStreamLogger ((string) null));
+			Assert.Throws<ArgumentNullException> (() => new ProtocolStreamLogger ((Stream) null));
+			using (var logger = new ProtocolStreamLogger (new MemoryStream ())) {
 				var buffer = new byte[1024];
 
 				Assert.Throws<ArgumentNullException> (() => logger.LogConnect (null));
@@ -61,7 +61,7 @@ namespace UnitTests {
 		public void TestLogging ()
 		{
 			using (var stream = new MemoryStream ()) {
-				using (var logger = new ProtocolLogger (stream, true)) {
+				using (var logger = new ProtocolStreamLogger (stream, true)) {
 					logger.LogConnect (new Uri ("pop://pop.skyfall.net:110"));
 
 					var cmd = Encoding.ASCII.GetBytes ("RETR 1\r\n");

--- a/UnitTests/Security/SslHandshakeExceptionTests.cs
+++ b/UnitTests/Security/SslHandshakeExceptionTests.cs
@@ -39,6 +39,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using NUnit.Framework;
 
 using MailKit;
+using MailKit.Logging;
 using MailKit.Security;
 
 using AuthenticationException = System.Security.Authentication.AuthenticationException;


### PR DESCRIPTION
 ---
Feature request : Support for Microsoft Extension Logging

Description:

 I use MailKit in my projects where different frameworks are used for logging (for example, NLog, SiriLog, etc.). There is a great idea and solution - to use a logging abstraction using [Microsoft. Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/) 
--- 
 
 - Rename old ProtocolLogger in ProtocolStreamLogger
 - Add new ProtocolLogger for logging implementation via Microsoft Extension Logging
 - Move all Loggers and it Interfaces to MailKit.Logging namespace
 - Move IDisposable from IProtocolLogger to implemetation ProtocolStreamLogger