### PR TITLE
Added GetMessageSizeAsync to IMailSpool

### DIFF
--- a/MailKit/IMailSpool.cs
+++ b/MailKit/IMailSpool.cs
@@ -77,6 +77,37 @@ namespace MailKit {
 		int GetMessageCount (CancellationToken cancellationToken = default (CancellationToken));
 
 		/// <summary>
+		/// Asynchronously get the message count.
+		/// </summary>
+		/// <remarks>
+		/// Asynchronously gets the message count.
+		/// </remarks>
+		/// <returns>The message count.</returns>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <exception cref="System.ObjectDisposedException">
+		/// The <see cref="MailSpool"/> has been disposed.
+		/// </exception>
+		/// <exception cref="ServiceNotConnectedException">
+		/// The <see cref="MailSpool"/> is not connected.
+		/// </exception>
+		/// <exception cref="ServiceNotAuthenticatedException">
+		/// The <see cref="MailSpool"/> is not authenticated.
+		/// </exception>
+		/// <exception cref="System.OperationCanceledException">
+		/// The operation was canceled via the cancellation token.
+		/// </exception>
+		/// <exception cref="System.IO.IOException">
+		/// An I/O error occurred.
+		/// </exception>
+		/// <exception cref="CommandException">
+		/// The command failed.
+		/// </exception>
+		/// <exception cref="ProtocolException">
+		/// A protocol error occurred.
+		/// </exception>
+		Task<int> GetMessageCountAsync (CancellationToken cancellationToken = default (CancellationToken));
+
+		/// <summary>
 		/// Get the UID of the message at the specified index.
 		/// </summary>
 		/// <remarks>

--- a/MailKit/IMailSpool.cs
+++ b/MailKit/IMailSpool.cs
@@ -84,27 +84,6 @@ namespace MailKit {
 		/// </remarks>
 		/// <returns>The message count.</returns>
 		/// <param name="cancellationToken">The cancellation token.</param>
-		/// <exception cref="System.ObjectDisposedException">
-		/// The <see cref="MailSpool"/> has been disposed.
-		/// </exception>
-		/// <exception cref="ServiceNotConnectedException">
-		/// The <see cref="MailSpool"/> is not connected.
-		/// </exception>
-		/// <exception cref="ServiceNotAuthenticatedException">
-		/// The <see cref="MailSpool"/> is not authenticated.
-		/// </exception>
-		/// <exception cref="System.OperationCanceledException">
-		/// The operation was canceled via the cancellation token.
-		/// </exception>
-		/// <exception cref="System.IO.IOException">
-		/// An I/O error occurred.
-		/// </exception>
-		/// <exception cref="CommandException">
-		/// The command failed.
-		/// </exception>
-		/// <exception cref="ProtocolException">
-		/// A protocol error occurred.
-		/// </exception>
 		Task<int> GetMessageCountAsync (CancellationToken cancellationToken = default (CancellationToken));
 
 		/// <summary>


### PR DESCRIPTION
For some reason GetMessageCountAsync was not part of the IMailSpool interface, so I added it.