### PR TITLE
Fix for PR #1270

### DIFF
--- a/MailKit/Net/NetworkStream.cs
+++ b/MailKit/Net/NetworkStream.cs
@@ -188,13 +188,13 @@ namespace MailKit.Net
 							return recv.BytesTransferred;
 						} catch (OperationCanceledException) {
 							Disconnect ();
+							if (timeout.IsCancellationRequested)
+								throw new TimeoutException ($"Operation timed out after {ReadTimeout} milliseconds", ex);
 							throw;
 						} catch (Exception ex) {
 							Disconnect ();
 							if (ex is SocketException)
 								throw new IOException (ex.Message, ex);
-							if (timeout.IsCancellationRequested)
-								throw new TimeoutException ($"Operation timed out after {ReadTimeout} milliseconds", ex);
 							throw;
 						}
 					}
@@ -230,13 +230,13 @@ namespace MailKit.Net
 							await tcs.Task.ConfigureAwait (false);
 						} catch (OperationCanceledException) {
 							Disconnect ();
+							if (timeout.IsCancellationRequested)
+								throw new TimeoutException ($"Operation timed out after {WriteTimeout} milliseconds", ex);
 							throw;
 						} catch (Exception ex) {
 							Disconnect ();
 							if (ex is SocketException)
 								throw new IOException (ex.Message, ex);
-							if (timeout.IsCancellationRequested)
-								throw new TimeoutException ($"Operation timed out after {WriteTimeout} milliseconds", ex);
 							throw;
 						}
 					}


### PR DESCRIPTION
A fix for my previous PR #1270. I've put the code in the wrong `catch` previously. Because `TaskCancelledException` is derived from `OperationCanceledException` - the timeout will actually occur inside the `catch (OperationCanceledException)` block. not the `catch (Exception ex)` block. Sorry about that!