### PR TITLE
Allow access to exceptions that caused disconnections from the server

### DIFF
--- a/MailKit/DisconnectedEventArgs.cs
+++ b/MailKit/DisconnectedEventArgs.cs
@@ -26,7 +26,6 @@
 
 using System;
 
-using MailKit.Net.Smtp;
 using MailKit.Security;
 
 namespace MailKit

--- a/MailKit/DisconnectedEventArgs.cs
+++ b/MailKit/DisconnectedEventArgs.cs
@@ -24,6 +24,7 @@
 // THE SOFTWARE.
 //
 
+using MailKit.Net.Smtp;
 using MailKit.Security;
 
 namespace MailKit
@@ -47,10 +48,12 @@ namespace MailKit
 		/// <param name="port">The port that the client was connected to.</param>
 		/// <param name="options">The SSL/TLS options that were used by the client.</param>
 		/// <param name="requested">If <c>true</c>, the <see cref="IMailService"/> was disconnected via the
+		/// <param name="smtpCommandException">The exception that caused the disconnect if relevant</param>
 		/// <see cref="IMailService.Disconnect(bool, System.Threading.CancellationToken)"/> method.</param>
-		public DisconnectedEventArgs (string host, int port, SecureSocketOptions options, bool requested) : base (host, port, options)
+		public DisconnectedEventArgs (string host, int port, SecureSocketOptions options, bool requested, SmtpCommandException smtpCommandException) : base (host, port, options)
 		{
 			IsRequested = requested;
+			SmtpCommandException = smtpCommandException;
 		}
 
 		/// <summary>
@@ -66,5 +69,10 @@ namespace MailKit
 		public bool IsRequested {
 			get; private set;
 		}
+
+		/// <summary>
+		/// The exception that caused the disconnect if relevant
+		/// </summary>
+		public SmtpCommandException SmtpCommandException { get; }
 	}
 }

--- a/MailKit/DisconnectedEventArgs.cs
+++ b/MailKit/DisconnectedEventArgs.cs
@@ -24,6 +24,8 @@
 // THE SOFTWARE.
 //
 
+using System;
+
 using MailKit.Net.Smtp;
 using MailKit.Security;
 
@@ -48,12 +50,12 @@ namespace MailKit
 		/// <param name="port">The port that the client was connected to.</param>
 		/// <param name="options">The SSL/TLS options that were used by the client.</param>
 		/// <param name="requested">If <c>true</c>, the <see cref="IMailService"/> was disconnected via the
-		/// <param name="smtpCommandException">The exception that caused the disconnect if relevant</param>
+		/// <param name="exception">The exception that caused the disconnect if relevant</param>
 		/// <see cref="IMailService.Disconnect(bool, System.Threading.CancellationToken)"/> method.</param>
-		public DisconnectedEventArgs (string host, int port, SecureSocketOptions options, bool requested, SmtpCommandException smtpCommandException) : base (host, port, options)
+		public DisconnectedEventArgs (string host, int port, SecureSocketOptions options, bool requested, Exception exception) : base (host, port, options)
 		{
 			IsRequested = requested;
-			SmtpCommandException = smtpCommandException;
+			Exception = exception;
 		}
 
 		/// <summary>
@@ -73,6 +75,6 @@ namespace MailKit
 		/// <summary>
 		/// The exception that caused the disconnect if relevant
 		/// </summary>
-		public SmtpCommandException SmtpCommandException { get; }
+		public Exception Exception { get; }
 	}
 }

--- a/MailKit/MailService.cs
+++ b/MailKit/MailService.cs
@@ -25,26 +25,26 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Text;
-using System.Threading;
-using System.Net.Sockets;
 using System.Net.Security;
-using System.Threading.Tasks;
-using System.Collections.Generic;
+using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
-using SslProtocols = System.Security.Authentication.SslProtocols;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 using MailKit.Net;
 using MailKit.Net.Proxy;
 using MailKit.Security;
 
 using NetworkStream = MailKit.Net.NetworkStream;
-using MailKit.Net.Smtp;
+using SslProtocols = System.Security.Authentication.SslProtocols;
 
-namespace MailKit {
+namespace MailKit
+{
 	/// <summary>
 	/// An abstract mail service implementation.
 	/// </summary>

--- a/MailKit/MailService.cs
+++ b/MailKit/MailService.cs
@@ -1746,10 +1746,10 @@ namespace MailKit {
 		/// <param name="port">The port that the client was connected to on the remote host.</param>
 		/// <param name="options">The SSL/TLS options that were used by the client.</param>
 		/// <param name="requested"><c>true</c> if the disconnect was explicitly requested; otherwise, <c>false</c>.</param>
-		/// <param name="smtpCommandException">The exception that caused the disconnect if relevant</param>
-		protected virtual void OnDisconnected (string host, int port, SecureSocketOptions options, bool requested, SmtpCommandException smtpCommandException = null)
+		/// <param name="exception">The exception that caused that disconnect if relevant</param>
+		protected virtual void OnDisconnected (string host, int port, SecureSocketOptions options, bool requested, Exception exception = null)
 		{
-			Disconnected?.Invoke (this, new DisconnectedEventArgs (host, port, options, requested, smtpCommandException));
+			Disconnected?.Invoke (this, new DisconnectedEventArgs (host, port, options, requested, exception));
 		}
 
 		/// <summary>

--- a/MailKit/MailService.cs
+++ b/MailKit/MailService.cs
@@ -42,6 +42,7 @@ using MailKit.Net.Proxy;
 using MailKit.Security;
 
 using NetworkStream = MailKit.Net.NetworkStream;
+using MailKit.Net.Smtp;
 
 namespace MailKit {
 	/// <summary>
@@ -1745,9 +1746,10 @@ namespace MailKit {
 		/// <param name="port">The port that the client was connected to on the remote host.</param>
 		/// <param name="options">The SSL/TLS options that were used by the client.</param>
 		/// <param name="requested"><c>true</c> if the disconnect was explicitly requested; otherwise, <c>false</c>.</param>
-		protected virtual void OnDisconnected (string host, int port, SecureSocketOptions options, bool requested)
+		/// <param name="smtpCommandException">The exception that caused the disconnect if relevant</param>
+		protected virtual void OnDisconnected (string host, int port, SecureSocketOptions options, bool requested, SmtpCommandException smtpCommandException = null)
 		{
-			Disconnected?.Invoke (this, new DisconnectedEventArgs (host, port, options, requested));
+			Disconnected?.Invoke (this, new DisconnectedEventArgs (host, port, options, requested, smtpCommandException));
 		}
 
 		/// <summary>

--- a/MailKit/Net/Smtp/SmtpClient.cs
+++ b/MailKit/Net/Smtp/SmtpClient.cs
@@ -1818,8 +1818,8 @@ namespace MailKit.Net.Smtp {
 
 			try {
 				response = await SendCommandAsync ("NOOP", doAsync, cancellationToken).ConfigureAwait (false);
-			} catch {
-				Disconnect (uri.Host, uri.Port, GetSecureSocketOptions (uri), false);
+			} catch (Exception exception) {
+				Disconnect (uri.Host, uri.Port, GetSecureSocketOptions (uri), false, exception);
 				throw;
 			}
 
@@ -1855,7 +1855,7 @@ namespace MailKit.Net.Smtp {
 			NoOpAsync (false, cancellationToken).GetAwaiter ().GetResult ();
 		}
 
-		void Disconnect (string host, int port, SecureSocketOptions options, bool requested, SmtpCommandException smtpCommandException = null)
+		void Disconnect (string host, int port, SecureSocketOptions options, bool requested, Exception exception = null)
 		{
 			capabilities = SmtpCapabilities.None;
 			authenticated = false;
@@ -1869,7 +1869,7 @@ namespace MailKit.Net.Smtp {
 			}
 
 			if (host != null)
-				OnDisconnected (host, port, options, requested, smtpCommandException);
+				OnDisconnected (host, port, options, requested, exception);
 		}
 
 #endregion
@@ -2565,8 +2565,8 @@ namespace MailKit.Net.Smtp {
 			} catch (SmtpCommandException smtpCommandException) {
 				await ResetAsync (doAsync, smtpCommandException, cancellationToken).ConfigureAwait (false);
 				throw;
-			} catch {
-				Disconnect (uri.Host, uri.Port, GetSecureSocketOptions (uri), false);
+			} catch (Exception exception) {
+				Disconnect (uri.Host, uri.Port, GetSecureSocketOptions (uri), false, exception);
 				throw;
 			}
 		}


### PR DESCRIPTION
HI I work in a team that works with the library and its worked great so thanks. Recently we came across an issue that was difficult to diagnose and upon solving the problem by aggregating and analysing outputs of the protocol logger we realised we had been disconnected and the hook provided did not provide details on why we had been disconnected. (It was google bouncing as we didnt have a header filled out correctly). 

The proposed changes allows the OnDisconnected override and event to access the exception that caused a Disconnect in the event it happens. 

- I could not find the best place to put tests in for this case but would be happy to work on the PR given any suggestions .
- The current implementation is a breaking change but im happy to make changes if theres a preference to how this could be introduced in a non breaking manner.