### PR TITLE
Fix typo in `HasFLags` in FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1691,7 +1691,7 @@ using (var client = new ImapClient ()) {
     
     IMailFolder sentMail;
     
-    if (client.Capabilities.HasFLag (ImapCapabilities.SpecialUse)) {
+    if (client.Capabilities.HasFlag (ImapCapabilities.SpecialUse)) {
         sentMail = client.GetFolder (SpecialFolder.Sent);
     } else {
         var personal = client.GetFolder (client.PersonalNamespaces[0]);


### PR DESCRIPTION
Fix typo in `HasFlags` method call in `SmtpClient` example (capital `L` instead of correct lowercase `l`)