### PR TITLE
Added all supported SASL mechanisms to SaslMechanism.Rank()

### DIFF
--- a/MailKit/Security/SaslMechanism.cs
+++ b/MailKit/Security/SaslMechanism.cs
@@ -57,10 +57,6 @@ namespace MailKit.Security {
 		/// <remarks>
 		/// <para>Used by the various clients when authenticating via SASL to determine
 		/// which order the SASL mechanisms supported by the server should be tried.</para>
-		/// <note type="note">Even though NTLM is more secure than PLAIN or LOGIN (and
-		/// probably others), it is tried last only because it is less reliable due to
-		/// missing functionality to make it 100% compatible with all NTLM server
-		/// implementations.</note>
 		/// </remarks>
 		static readonly string[] RankedAuthenticationMechanisms;
 		static readonly bool md5supported;
@@ -85,18 +81,18 @@ namespace MailKit.Security {
 				supported.Add ("DIGEST-MD5");
 				supported.Add ("CRAM-MD5");
 			}
+			supported.Add ("OAUTHBEARER");
+			supported.Add ("XOAUTH2");
 			supported.Add ("PLAIN");
 			supported.Add ("LOGIN");
+			// supported.Add ("ANONYMOUS");
 
 			RankedAuthenticationMechanisms = supported.ToArray ();
 		}
 
 		/// <summary>
-		/// Rank authentication mechanisms in order of security.
+		/// Rank authentication mechanisms in order of security, whilst removing unsupported or unnecessary mechanisms.
 		/// </summary>
-		/// <remarks>
-		/// <para>Ranks authentication machisms in order of security.</para>
-		/// </remarks>
 		/// <param name="authenticationMechanisms">The authentication mechanisms supported by the server.</param>
 		/// <returns>The supported authentication mechanisms in ranked order.</returns>
 		internal static IEnumerable<string> Rank (HashSet<string> authenticationMechanisms)


### PR DESCRIPTION
This fixes an issue where OAuth-supported SMTP servers fail to authenticate when calling the `SmtpClient.Authenticate(ICredentials)` overload, since internally calling `SaslMechanism.Rank()` removes `XOAUTH2`.

Workaround: use `SmtpClient.Authenticate(SaslMechanism)` overload, or patch the private static field:

```csharp
static void PatchMailKitSupportedSaslMechanisms()
{
    // Begin MailKit.Security.SaslMechanism static constructor
    var md5supported = false;
    try
    {
        using (var md5 = System.Security.Cryptography.MD5.Create())
            md5supported = true;
    }
    catch { }

    var supported = new List<string> {
        "SCRAM-SHA-512",
        "SCRAM-SHA-256",
        "SCRAM-SHA-1",
        "NTLM"
    };
    if (md5supported)
    {
        supported.Add("DIGEST-MD5");
        supported.Add("CRAM-MD5");
    }
    supported.Add("OAUTHBEARER");
    supported.Add("XOAUTH2");
    supported.Add("PLAIN");
    supported.Add("LOGIN");
    // End MailKit.Security.SaslMechanism static constructor

    var f = typeof(SaslMechanism).GetField("RankedAuthenticationMechanisms", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
    f.SetValue(null, supported.ToArray());
}
```