### PR TITLE
Fixed typo in ExchangeOAuth2.md

### DIFF
--- a/ExchangeOAuth2.md
+++ b/ExchangeOAuth2.md
@@ -60,5 +60,5 @@ var authToken = await publicClientApplication.AcquireTokenSilent(scopes, account
 
 ## Additional Resources
 
-For more inforrmation, check out the [Microsoft.Identity.Client](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identity.client?view=azure-dotnet)
+For more information, check out the [Microsoft.Identity.Client](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identity.client?view=azure-dotnet)
 documentation.


### PR DESCRIPTION
Fixed a typo in `ExchangeOAuth2.md` (from `inforrmation` to `information`).