### PR TITLE
Fix: SecureSocketOptions.Auto shouldn't use SSL on port 25

### DIFF
--- a/MailKit/Net/Smtp/SmtpClient.cs
+++ b/MailKit/Net/Smtp/SmtpClient.cs
@@ -1267,6 +1267,7 @@ namespace MailKit.Net.Smtp {
 			case SecureSocketOptions.Auto:
 				switch (port) {
 				case 0: port = 25; goto default;
+				case 25: goto default;
 				case 465: options = SecureSocketOptions.SslOnConnect; break;
 				default: options = SecureSocketOptions.StartTlsWhenAvailable; break;
 				}


### PR DESCRIPTION
It's weird that the `Auto` options is using SSL on port 25, but not on port 0! We implemented workaround for now https://github.com/btcpayserver/btcpayserver/commit/9423bc4ea71747809b029dadfdf3545d5a6d0b68

Found after user complained on 
https://github.com/btcpayserver/btcpayserver/discussions/3895#discussioncomment-3017467