### PR TITLE
Added an ImapToken cache to try and reduce ImapToken allocations

### DIFF
--- a/MailKit/ByteArrayBuilder.cs
+++ b/MailKit/ByteArrayBuilder.cs
@@ -45,6 +45,15 @@ namespace MailKit
 			get { return length; }
 		}
 
+		public byte this[int index] {
+			get { return buffer[index]; }
+		}
+
+		public byte[] GetBuffer ()
+		{
+			return buffer;
+		}
+
 		void EnsureCapacity (int capacity)
 		{
 			if (capacity > buffer.Length) {

--- a/MailKit/MailKit.csproj
+++ b/MailKit/MailKit.csproj
@@ -64,6 +64,7 @@
 
   <ItemGroup>
     <Compile Include="Net\Imap\AsyncImapClient.cs" />
+    <Compile Include="Net\Imap\HashCode.cs" Condition=" $(TargetFramework.StartsWith('net4')) Or '$(TargetFramework)' == 'netstandard2.0' " />
     <Compile Include="Net\Imap\IImapClient.cs" />
     <Compile Include="Net\Imap\IImapFolder.cs" />
     <Compile Include="Net\Imap\ImapAuthenticationSecretDetector.cs" />
@@ -88,6 +89,7 @@
     <Compile Include="Net\Imap\ImapSearchQueryOptimizer.cs" />
     <Compile Include="Net\Imap\ImapStream.cs" />
     <Compile Include="Net\Imap\ImapToken.cs" />
+    <Compile Include="Net\Imap\ImapTokenCache.cs" />
     <Compile Include="Net\Imap\ImapUtils.cs" />
     <Compile Include="Net\Pop3\AsyncPop3Client.cs" />
     <Compile Include="Net\Pop3\IPop3Client.cs" />

--- a/MailKit/MailKitLite.csproj
+++ b/MailKit/MailKitLite.csproj
@@ -69,6 +69,7 @@
 
   <ItemGroup>
     <Compile Include="Net\Imap\AsyncImapClient.cs" />
+    <Compile Include="Net\Imap\HashCode.cs" Condition=" $(TargetFramework.StartsWith('net4')) Or '$(TargetFramework)' == 'netstandard2.0' " />
     <Compile Include="Net\Imap\IImapClient.cs" />
     <Compile Include="Net\Imap\IImapFolder.cs" />
     <Compile Include="Net\Imap\ImapAuthenticationSecretDetector.cs" />
@@ -93,6 +94,7 @@
     <Compile Include="Net\Imap\ImapSearchQueryOptimizer.cs" />
     <Compile Include="Net\Imap\ImapStream.cs" />
     <Compile Include="Net\Imap\ImapToken.cs" />
+    <Compile Include="Net\Imap\ImapTokenCache.cs" />
     <Compile Include="Net\Imap\ImapUtils.cs" />
     <Compile Include="Net\Pop3\AsyncPop3Client.cs" />
     <Compile Include="Net\Pop3\IPop3Client.cs" />

--- a/MailKit/Net/Imap/HashCode.cs
+++ b/MailKit/Net/Imap/HashCode.cs
@@ -1,0 +1,521 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*
+
+The xxHash32 implementation is based on the code published by Yann Collet:
+https://raw.githubusercontent.com/Cyan4973/xxHash/5c174cfa4e45a42f94082dc0d4539b39696afea1/xxhash.c
+
+  xxHash - Fast Hash algorithm
+  Copyright (C) 2012-2016, Yann Collet
+
+  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+  * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  You can contact the author at :
+  - xxHash homepage: http://www.xxhash.com
+  - xxHash source repository : https://github.com/Cyan4973/xxHash
+
+*/
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+
+#pragma warning disable CA1066 // Implement IEquatable when overriding Object.Equals
+
+namespace MailKit.Net.Imap
+{
+	// xxHash32 is used for the hash code.
+	// https://github.com/Cyan4973/xxHash
+
+	struct HashCode
+	{
+		private static readonly uint s_seed = GenerateGlobalSeed ();
+
+		private const uint Prime1 = 2654435761U;
+		private const uint Prime2 = 2246822519U;
+		private const uint Prime3 = 3266489917U;
+		private const uint Prime4 = 668265263U;
+		private const uint Prime5 = 374761393U;
+
+		private uint _v1, _v2, _v3, _v4;
+		private uint _queue1, _queue2, _queue3;
+		private uint _length;
+
+		private static unsafe uint GenerateGlobalSeed ()
+		{
+			var data = new byte[sizeof (uint)];
+			uint result = 0;
+
+			using (var random = RandomNumberGenerator.Create ())
+				random.GetBytes (data);
+
+			for (int i = 0; i < data.Length; i++)
+				result <<= data[i];
+
+			return result;
+		}
+
+		public static int Combine<T1> (T1 value1)
+		{
+			// Provide a way of diffusing bits from something with a limited
+			// input hash space. For example, many enums only have a few
+			// possible hashes, only using the bottom few bits of the code. Some
+			// collections are built on the assumption that hashes are spread
+			// over a larger space, so diffusing the bits may help the
+			// collection work more efficiently.
+
+			uint hc1 = (uint) (value1?.GetHashCode () ?? 0);
+
+			uint hash = MixEmptyState ();
+			hash += 4;
+
+			hash = QueueRound (hash, hc1);
+
+			hash = MixFinal (hash);
+			return (int) hash;
+		}
+
+		public static int Combine<T1, T2> (T1 value1, T2 value2)
+		{
+			uint hc1 = (uint) (value1?.GetHashCode () ?? 0);
+			uint hc2 = (uint) (value2?.GetHashCode () ?? 0);
+
+			uint hash = MixEmptyState ();
+			hash += 8;
+
+			hash = QueueRound (hash, hc1);
+			hash = QueueRound (hash, hc2);
+
+			hash = MixFinal (hash);
+			return (int) hash;
+		}
+
+		public static int Combine<T1, T2, T3> (T1 value1, T2 value2, T3 value3)
+		{
+			uint hc1 = (uint) (value1?.GetHashCode () ?? 0);
+			uint hc2 = (uint) (value2?.GetHashCode () ?? 0);
+			uint hc3 = (uint) (value3?.GetHashCode () ?? 0);
+
+			uint hash = MixEmptyState ();
+			hash += 12;
+
+			hash = QueueRound (hash, hc1);
+			hash = QueueRound (hash, hc2);
+			hash = QueueRound (hash, hc3);
+
+			hash = MixFinal (hash);
+			return (int) hash;
+		}
+
+		public static int Combine<T1, T2, T3, T4> (T1 value1, T2 value2, T3 value3, T4 value4)
+		{
+			uint hc1 = (uint) (value1?.GetHashCode () ?? 0);
+			uint hc2 = (uint) (value2?.GetHashCode () ?? 0);
+			uint hc3 = (uint) (value3?.GetHashCode () ?? 0);
+			uint hc4 = (uint) (value4?.GetHashCode () ?? 0);
+
+			Initialize (out uint v1, out uint v2, out uint v3, out uint v4);
+
+			v1 = Round (v1, hc1);
+			v2 = Round (v2, hc2);
+			v3 = Round (v3, hc3);
+			v4 = Round (v4, hc4);
+
+			uint hash = MixState (v1, v2, v3, v4);
+			hash += 16;
+
+			hash = MixFinal (hash);
+			return (int) hash;
+		}
+
+		public static int Combine<T1, T2, T3, T4, T5> (T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+		{
+			uint hc1 = (uint) (value1?.GetHashCode () ?? 0);
+			uint hc2 = (uint) (value2?.GetHashCode () ?? 0);
+			uint hc3 = (uint) (value3?.GetHashCode () ?? 0);
+			uint hc4 = (uint) (value4?.GetHashCode () ?? 0);
+			uint hc5 = (uint) (value5?.GetHashCode () ?? 0);
+
+			Initialize (out uint v1, out uint v2, out uint v3, out uint v4);
+
+			v1 = Round (v1, hc1);
+			v2 = Round (v2, hc2);
+			v3 = Round (v3, hc3);
+			v4 = Round (v4, hc4);
+
+			uint hash = MixState (v1, v2, v3, v4);
+			hash += 20;
+
+			hash = QueueRound (hash, hc5);
+
+			hash = MixFinal (hash);
+			return (int) hash;
+		}
+
+		public static int Combine<T1, T2, T3, T4, T5, T6> (T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
+		{
+			uint hc1 = (uint) (value1?.GetHashCode () ?? 0);
+			uint hc2 = (uint) (value2?.GetHashCode () ?? 0);
+			uint hc3 = (uint) (value3?.GetHashCode () ?? 0);
+			uint hc4 = (uint) (value4?.GetHashCode () ?? 0);
+			uint hc5 = (uint) (value5?.GetHashCode () ?? 0);
+			uint hc6 = (uint) (value6?.GetHashCode () ?? 0);
+
+			Initialize (out uint v1, out uint v2, out uint v3, out uint v4);
+
+			v1 = Round (v1, hc1);
+			v2 = Round (v2, hc2);
+			v3 = Round (v3, hc3);
+			v4 = Round (v4, hc4);
+
+			uint hash = MixState (v1, v2, v3, v4);
+			hash += 24;
+
+			hash = QueueRound (hash, hc5);
+			hash = QueueRound (hash, hc6);
+
+			hash = MixFinal (hash);
+			return (int) hash;
+		}
+
+		public static int Combine<T1, T2, T3, T4, T5, T6, T7> (T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
+		{
+			uint hc1 = (uint) (value1?.GetHashCode () ?? 0);
+			uint hc2 = (uint) (value2?.GetHashCode () ?? 0);
+			uint hc3 = (uint) (value3?.GetHashCode () ?? 0);
+			uint hc4 = (uint) (value4?.GetHashCode () ?? 0);
+			uint hc5 = (uint) (value5?.GetHashCode () ?? 0);
+			uint hc6 = (uint) (value6?.GetHashCode () ?? 0);
+			uint hc7 = (uint) (value7?.GetHashCode () ?? 0);
+
+			Initialize (out uint v1, out uint v2, out uint v3, out uint v4);
+
+			v1 = Round (v1, hc1);
+			v2 = Round (v2, hc2);
+			v3 = Round (v3, hc3);
+			v4 = Round (v4, hc4);
+
+			uint hash = MixState (v1, v2, v3, v4);
+			hash += 28;
+
+			hash = QueueRound (hash, hc5);
+			hash = QueueRound (hash, hc6);
+			hash = QueueRound (hash, hc7);
+
+			hash = MixFinal (hash);
+			return (int) hash;
+		}
+
+		public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8> (T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8)
+		{
+			uint hc1 = (uint) (value1?.GetHashCode () ?? 0);
+			uint hc2 = (uint) (value2?.GetHashCode () ?? 0);
+			uint hc3 = (uint) (value3?.GetHashCode () ?? 0);
+			uint hc4 = (uint) (value4?.GetHashCode () ?? 0);
+			uint hc5 = (uint) (value5?.GetHashCode () ?? 0);
+			uint hc6 = (uint) (value6?.GetHashCode () ?? 0);
+			uint hc7 = (uint) (value7?.GetHashCode () ?? 0);
+			uint hc8 = (uint) (value8?.GetHashCode () ?? 0);
+
+			Initialize (out uint v1, out uint v2, out uint v3, out uint v4);
+
+			v1 = Round (v1, hc1);
+			v2 = Round (v2, hc2);
+			v3 = Round (v3, hc3);
+			v4 = Round (v4, hc4);
+
+			v1 = Round (v1, hc5);
+			v2 = Round (v2, hc6);
+			v3 = Round (v3, hc7);
+			v4 = Round (v4, hc8);
+
+			uint hash = MixState (v1, v2, v3, v4);
+			hash += 32;
+
+			hash = MixFinal (hash);
+			return (int) hash;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static void Initialize (out uint v1, out uint v2, out uint v3, out uint v4)
+		{
+			v1 = s_seed + Prime1 + Prime2;
+			v2 = s_seed + Prime2;
+			v3 = s_seed;
+			v4 = s_seed - Prime1;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		static uint RotateLeft (uint value, int offset)
+		{
+			return (value << offset) | (value >> (32 - offset));
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static uint Round (uint hash, uint input)
+		{
+			return RotateLeft (hash + input * Prime2, 13) * Prime1;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static uint QueueRound (uint hash, uint queuedValue)
+		{
+			return RotateLeft (hash + queuedValue * Prime3, 17) * Prime4;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static uint MixState (uint v1, uint v2, uint v3, uint v4)
+		{
+			return RotateLeft (v1, 1) + RotateLeft (v2, 7) + RotateLeft (v3, 12) + RotateLeft (v4, 18);
+		}
+
+		private static uint MixEmptyState ()
+		{
+			return s_seed + Prime5;
+		}
+
+		[MethodImpl (MethodImplOptions.AggressiveInlining)]
+		private static uint MixFinal (uint hash)
+		{
+			hash ^= hash >> 15;
+			hash *= Prime2;
+			hash ^= hash >> 13;
+			hash *= Prime3;
+			hash ^= hash >> 16;
+			return hash;
+		}
+
+		public void Add<T> (T value)
+		{
+			Add (value?.GetHashCode () ?? 0);
+		}
+
+		public void Add<T> (T value, IEqualityComparer<T>? comparer)
+		{
+			Add (value is null ? 0 : (comparer?.GetHashCode (value) ?? value.GetHashCode ()));
+		}
+
+		static int ByteOffset (ref byte origin, ref byte target)
+		{
+			var x = target - origin;
+
+			return x;
+		}
+
+		/// <summary>Adds a span of bytes to the hash code.</summary>
+		/// <param name="value">The span.</param>
+		/// <remarks>
+		/// This method does not guarantee that the result of adding a span of bytes will match
+		/// the result of adding the same bytes individually.
+		/// </remarks>
+		public void AddBytes (ReadOnlySpan<byte> value)
+		{
+			ref byte pos = ref MemoryMarshal.GetReference (value);
+			ref byte end = ref Unsafe.Add (ref pos, value.Length);
+
+			if (value.Length < (sizeof (int) * 4)) {
+				goto Small;
+			}
+
+			// Usually Add calls Initialize but if we haven't used HashCode before it won't have been called.
+			if (_length == 0) {
+				Initialize (out _v1, out _v2, out _v3, out _v4);
+			} else {
+				// If we have at least 16 bytes to hash, we can add them in 16-byte batches,
+				// but we first have to add enough data to flush any queued values.
+				switch (_length % 4) {
+				case 1:
+					//Debug.Assert (Unsafe.ByteOffset (ref pos, ref end) >= sizeof (int));
+					Add (Unsafe.ReadUnaligned<int> (ref pos));
+					pos = ref Unsafe.Add (ref pos, sizeof (int));
+					goto case 2;
+				case 2:
+					//Debug.Assert (Unsafe.ByteOffset (ref pos, ref end) >= sizeof (int));
+					Add (Unsafe.ReadUnaligned<int> (ref pos));
+					pos = ref Unsafe.Add (ref pos, sizeof (int));
+					goto case 3;
+				case 3:
+					//Debug.Assert (Unsafe.ByteOffset (ref pos, ref end) >= sizeof (int));
+					Add (Unsafe.ReadUnaligned<int> (ref pos));
+					pos = ref Unsafe.Add (ref pos, sizeof (int));
+					break;
+				}
+			}
+
+			// With the queue clear, we add sixteen bytes at a time until the input has fewer than sixteen bytes remaining.
+			// We first have to round the end pointer to the nearest 16-byte block from the offset. This makes the loop's condition simpler.
+			ref byte blockEnd = ref Unsafe.Subtract (ref end, ByteOffset (ref pos, ref end) % (sizeof (int) * 4));
+			while (Unsafe.IsAddressLessThan (ref pos, ref blockEnd)) {
+				//Debug.Assert (Unsafe.ByteOffset (ref pos, ref blockEnd) >= (sizeof (int) * 4));
+				uint v1 = Unsafe.ReadUnaligned<uint> (ref pos);
+				_v1 = Round (_v1, v1);
+				uint v2 = Unsafe.ReadUnaligned<uint> (ref Unsafe.Add (ref pos, sizeof (int) * 1));
+				_v2 = Round (_v2, v2);
+				uint v3 = Unsafe.ReadUnaligned<uint> (ref Unsafe.Add (ref pos, sizeof (int) * 2));
+				_v3 = Round (_v3, v3);
+				uint v4 = Unsafe.ReadUnaligned<uint> (ref Unsafe.Add (ref pos, sizeof (int) * 3));
+				_v4 = Round (_v4, v4);
+
+				_length += 4;
+				pos = ref Unsafe.Add (ref pos, sizeof (int) * 4);
+			}
+
+		Small:
+			// Add four bytes at a time until the input has fewer than four bytes remaining.
+			while (ByteOffset (ref pos, ref end) >= sizeof (int)) {
+				Add (Unsafe.ReadUnaligned<int> (ref pos));
+				pos = ref Unsafe.Add (ref pos, sizeof (int));
+			}
+
+			// Add the remaining bytes a single byte at a time.
+			while (Unsafe.IsAddressLessThan (ref pos, ref end)) {
+				Add ((int) pos);
+				pos = ref Unsafe.Add (ref pos, 1);
+			}
+		}
+
+		private void Add (int value)
+		{
+			// The original xxHash works as follows:
+			// 0. Initialize immediately. We can't do this in a struct (no
+			//    default ctor).
+			// 1. Accumulate blocks of length 16 (4 uints) into 4 accumulators.
+			// 2. Accumulate remaining blocks of length 4 (1 uint) into the
+			//    hash.
+			// 3. Accumulate remaining blocks of length 1 into the hash.
+
+			// There is no need for #3 as this type only accepts ints. _queue1,
+			// _queue2 and _queue3 are basically a buffer so that when
+			// ToHashCode is called we can execute #2 correctly.
+
+			// We need to initialize the xxHash32 state (_v1 to _v4) lazily (see
+			// #0) nd the last place that can be done if you look at the
+			// original code is just before the first block of 16 bytes is mixed
+			// in. The xxHash32 state is never used for streams containing fewer
+			// than 16 bytes.
+
+			// To see what's really going on here, have a look at the Combine
+			// methods.
+
+			uint val = (uint) value;
+
+			// Storing the value of _length locally shaves of quite a few bytes
+			// in the resulting machine code.
+			uint previousLength = _length++;
+			uint position = previousLength % 4;
+
+			// Switch can't be inlined.
+
+			if (position == 0)
+				_queue1 = val;
+			else if (position == 1)
+				_queue2 = val;
+			else if (position == 2)
+				_queue3 = val;
+			else // position == 3
+			{
+				if (previousLength == 3)
+					Initialize (out _v1, out _v2, out _v3, out _v4);
+
+				_v1 = Round (_v1, _queue1);
+				_v2 = Round (_v2, _queue2);
+				_v3 = Round (_v3, _queue3);
+				_v4 = Round (_v4, val);
+			}
+		}
+
+		public int ToHashCode ()
+		{
+			// Storing the value of _length locally shaves of quite a few bytes
+			// in the resulting machine code.
+			uint length = _length;
+
+			// position refers to the *next* queue position in this method, so
+			// position == 1 means that _queue1 is populated; _queue2 would have
+			// been populated on the next call to Add.
+			uint position = length % 4;
+
+			// If the length is less than 4, _v1 to _v4 don't contain anything
+			// yet. xxHash32 treats this differently.
+
+			uint hash = length < 4 ? MixEmptyState () : MixState (_v1, _v2, _v3, _v4);
+
+			// _length is incremented once per Add(Int32) and is therefore 4
+			// times too small (xxHash length is in bytes, not ints).
+
+			hash += length * 4;
+
+			// Mix what remains in the queue
+
+			// Switch can't be inlined right now, so use as few branches as
+			// possible by manually excluding impossible scenarios (position > 1
+			// is always false if position is not > 0).
+			if (position > 0) {
+				hash = QueueRound (hash, _queue1);
+				if (position > 1) {
+					hash = QueueRound (hash, _queue2);
+					if (position > 2)
+						hash = QueueRound (hash, _queue3);
+				}
+			}
+
+			hash = MixFinal (hash);
+			return (int) hash;
+		}
+
+#pragma warning disable 0809
+		// Obsolete member 'memberA' overrides non-obsolete member 'memberB'.
+		// Disallowing GetHashCode and Equals is by design
+
+		// * We decided to not override GetHashCode() to produce the hash code
+		//   as this would be weird, both naming-wise as well as from a
+		//   behavioral standpoint (GetHashCode() should return the object's
+		//   hash code, not the one being computed).
+
+		// * Even though ToHashCode() can be called safely multiple times on
+		//   this implementation, it is not part of the contract. If the
+		//   implementation has to change in the future we don't want to worry
+		//   about people who might have incorrectly used this type.
+
+		[Obsolete ("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", error: true)]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public override int GetHashCode () => throw new NotSupportedException ();
+
+		[Obsolete ("HashCode is a mutable struct and should not be compared with other HashCodes.", error: true)]
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		public override bool Equals (object? obj) => throw new NotSupportedException ();
+#pragma warning restore 0809
+	}
+}
+
+#pragma warning restore CA106

--- a/MailKit/Net/Imap/ImapTokenCache.cs
+++ b/MailKit/Net/Imap/ImapTokenCache.cs
@@ -1,0 +1,170 @@
+﻿//
+// ImapTokenCache.cs
+//
+// Author: Jeffrey Stedfast <jestedfa@microsoft.com>
+//
+// Copyright (c) 2013-2023 .NET Foundation and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+
+namespace MailKit.Net.Imap
+{
+	class ImapTokenCache
+	{
+		const int capacity = 128;
+
+		readonly Dictionary<ImapTokenKey, LinkedListNode<ImapTokenItem>> cache;
+		readonly LinkedList<ImapTokenItem> list;
+
+		public ImapTokenCache ()
+		{
+			cache = new Dictionary<ImapTokenKey, LinkedListNode<ImapTokenItem>> ();
+			list = new LinkedList<ImapTokenItem> ();
+		}
+
+		public ImapToken AddOrGet (ImapTokenType type, ByteArrayBuilder builder)
+		{
+			// Note: This ImapTokenKey .ctor does not duplicate the buffer and is meant as a temporary key
+			// in order to avoid memory allocations for lookup purposes.
+			var key = new ImapTokenKey (builder.GetBuffer (), builder.Length);
+
+			lock (cache) {
+				if (cache.TryGetValue (key, out var node)) {
+					// move the node to the head of the list
+					list.Remove (node);
+					list.AddFirst (node);
+
+					return node.Value.Token;
+				}
+
+				if (cache.Count >= capacity) {
+					// remove the least recently used token
+					node = list.Last;
+					list.RemoveLast ();
+					cache.Remove (node.Value.Key);
+				}
+
+				var token = new ImapToken (type, builder.ToString ());
+
+				// Note: We recreate the key here so we have a permanent key. Also this allows for reuse of the token's Value string.
+				key = new ImapTokenKey ((string) token.Value);
+
+				var item = new ImapTokenItem (key, token);
+
+				node = new LinkedListNode<ImapTokenItem> (item);
+				cache.Add (key, node);
+				list.AddFirst (node);
+
+				return token;
+			}
+		}
+
+		class ImapTokenKey
+		{
+			readonly byte[] byteArrayKey;
+			readonly string stringKey;
+			readonly int length;
+			readonly int hashCode;
+
+			public ImapTokenKey (byte[] key, int len)
+			{
+				byteArrayKey = key;
+				length = len;
+
+				var hash = new HashCode ();
+				for (int i = 0; i < length; i++)
+					hash.Add ((char) key[i]);
+
+				hashCode = hash.ToHashCode ();
+			}
+
+			public ImapTokenKey (string key)
+			{
+				stringKey = key;
+				length = key.Length;
+
+				var hash = new HashCode ();
+				for (int i = 0; i < length; i++)
+					hash.Add (key[i]);
+
+				hashCode = hash.ToHashCode ();
+			}
+
+			static bool Equals (string str, byte[] bytes)
+			{
+				for (int i = 0; i < str.Length; i++) {
+					if (str[i] != (char) bytes[i])
+						return false;
+				}
+
+				return true;
+			}
+
+			static bool Equals (ImapTokenKey self, ImapTokenKey other)
+			{
+				if (self.length != other.length)
+					return false;
+
+				if (self.stringKey != null) {
+					if (other.stringKey != null)
+						return self.stringKey.Equals (other.stringKey, StringComparison.Ordinal);
+
+					return Equals (self.stringKey, other.byteArrayKey);
+				}
+
+				if (other.stringKey != null)
+					return Equals (other.stringKey, self.byteArrayKey);
+
+				for (int i = 0; i < self.length; i++) {
+					if (self.byteArrayKey[i] != other.byteArrayKey[i])
+						return false;
+				}
+
+				return true;
+			}
+
+			public override bool Equals (object obj)
+			{
+				return obj is ImapTokenKey other && Equals (this, other);
+			}
+
+			public override int GetHashCode ()
+			{
+				return hashCode;
+			}
+		}
+
+		class ImapTokenItem
+		{
+			public readonly ImapTokenKey Key;
+			public readonly ImapToken Token;
+
+			public ImapTokenItem (ImapTokenKey key, ImapToken token)
+			{
+				Key = key;
+				Token = token;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Unfortunately, it seems not to really help much since the vast majority of tokens are either QStrings (not cached) or numeric tokens (also not cached since it wouldn't make sense).

I could look into caching qstring tokens as well, but it gets more complicated if they aren't us-ascii.

Also might be worth adding the ImapTokenType to the hash code calculation... right now it's not needed because we only cache atom and flag tokens (which won't collide). QString tokens might since the tokens would be unquoted.