### PR TITLE
doc: add link to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,8 +575,9 @@ string. Please include the `Exception.StackTrace` as well. The `Message`, by its
 
 ## Documentation
 
-API documentation can be found at [https://www.mimekit.net/docs](https://www.mimekit.net/docs).  
-More elaborate, complete, examples can also be found in this repository at [`Documentation/Examples`](Documentation/Examples). 
+API documentation can be found at [https://www.mimekit.net/docs](https://www.mimekit.net/docs).
+
+Some example snippets can also be found in the [`Documentation/Examples`](https://github.com/jstedfast/MailKit/tree/master/Documentation/Examples) directory.
 
 A copy of the XML-formatted API reference documentation is also included in the NuGet package.
 

--- a/README.md
+++ b/README.md
@@ -575,7 +575,8 @@ string. Please include the `Exception.StackTrace` as well. The `Message`, by its
 
 ## Documentation
 
-API documentation can be found at [https://www.mimekit.net/docs](https://www.mimekit.net/docs).
+API documentation can be found at [https://www.mimekit.net/docs](https://www.mimekit.net/docs).  
+More elaborate, complete, examples can also be found in this repository at [`Documentation/Examples`](Documentation/Examples). 
 
 A copy of the XML-formatted API reference documentation is also included in the NuGet package.
 


### PR DESCRIPTION
As a new user of this library, looking into the Readme and docs for the first time, I struggled to find the amazing(!) complete examples provided in the documentation.

IMHO thus giving a short link there, that there are more examples, is very helpful!