### PR TITLE
FormatInternalDate outputs wrong formatted dates with timezones having negative offsets

### DIFF
--- a/MailKit/Net/Imap/ImapUtils.cs
+++ b/MailKit/Net/Imap/ImapUtils.cs
@@ -61,10 +61,9 @@ namespace MailKit.Net.Imap {
 		/// <param name="date">The date.</param>
 		public static string FormatInternalDate (DateTimeOffset date)
 		{
-			string offset = $"{((date.Offset >= TimeSpan.Zero) ? "+" : "-")}{date.Offset.ToString("hhmm", CultureInfo.InvariantCulture)}";
-
-			return string.Format (CultureInfo.InvariantCulture, "{0:D2}-{1}-{2:D4} {3:D2}:{4:D2}:{5:D2} {6}",
-				date.Day, Months[date.Month - 1], date.Year, date.Hour, date.Minute, date.Second, offset);
+			return string.Format (CultureInfo.InvariantCulture, "{0:D2}-{1}-{2:D4} {3:D2}:{4:D2}:{5:D2} {6:+00;-00}{7:00}",
+				date.Day, Months[date.Month - 1], date.Year, date.Hour, date.Minute, date.Second,
+				date.Offset.Hours, Math.Abs (date.Offset.Minutes));
 		}
 
 		static bool TryGetInt32 (string text, ref int index, out int value)

--- a/MailKit/Net/Imap/ImapUtils.cs
+++ b/MailKit/Net/Imap/ImapUtils.cs
@@ -61,9 +61,10 @@ namespace MailKit.Net.Imap {
 		/// <param name="date">The date.</param>
 		public static string FormatInternalDate (DateTimeOffset date)
 		{
-			return string.Format (CultureInfo.InvariantCulture, "{0:D2}-{1}-{2:D4} {3:D2}:{4:D2}:{5:D2} {6:+00;-00}{7:00}",
-				date.Day, Months[date.Month - 1], date.Year, date.Hour, date.Minute, date.Second,
-				date.Offset.Hours, date.Offset.Minutes);
+			string offset = $"{((date.Offset >= TimeSpan.Zero) ? "+" : "-")}{date.Offset.ToString("hhmm", CultureInfo.InvariantCulture)}";
+
+			return string.Format (CultureInfo.InvariantCulture, "{0:D2}-{1}-{2:D4} {3:D2}:{4:D2}:{5:D2} {6}",
+				date.Day, Months[date.Month - 1], date.Year, date.Hour, date.Minute, date.Second, offset);
 		}
 
 		static bool TryGetInt32 (string text, ref int index, out int value)

--- a/UnitTests/Net/Imap/ImapUtilsTests.cs
+++ b/UnitTests/Net/Imap/ImapUtilsTests.cs
@@ -4284,13 +4284,15 @@ namespace UnitTests.Net.Imap {
 		}
 
 		[Test]
+		[TestCase (2023, 5, 14, 12, 30, 45, -4, -30, "14-May-2023 12:30:45 -0430")] // Sunday
+		[TestCase (2023, 5, 15, 12, 30, 45, -3, -30, "15-May-2023 12:30:45 -0330")] // Monday
 		[TestCase (2023, 5, 16, 12, 30, 45, -2, 0, "16-May-2023 12:30:45 -0200")]   // Tuesday
 		[TestCase (2023, 5, 17, 12, 30, 45, -1, 0, "17-May-2023 12:30:45 -0100")]   // Wednesday
 		public void TestFormatInternalDateNegativeOffsets (int year, int month, int day, int hour, int minute, int second, int offsetHours, int offsetMinutes, string expected)
 		{
 			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
 
-			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
+			string formattedInternalDate = ImapUtils.FormatInternalDate(date);
 
 			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
 		}
@@ -4304,7 +4306,7 @@ namespace UnitTests.Net.Imap {
 		{
 			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
 
-			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
+			string formattedInternalDate = ImapUtils.FormatInternalDate(date);
 
 			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
 		}
@@ -4315,18 +4317,19 @@ namespace UnitTests.Net.Imap {
 		{
 			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
 
-			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
+			string formattedInternalDate = ImapUtils.FormatInternalDate(date);
 
 			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
 		}
 
 		[Test]
 		[TestCase (2023, 5, 23, 23, 59, 59, 2, 30, "23-May-2023 23:59:59 +0230")]  // Tuesday
+		[TestCase (2023, 5, 24, 0, 0, 0, -4, -30, "24-May-2023 00:00:00 -0430")]  // Wednesday
 		public void TestFormatInternalDateEdgeCases (int year, int month, int day, int hour, int minute, int second, int offsetHours, int offsetMinutes, string expected)
 		{
 			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
 
-			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
+			string formattedInternalDate = ImapUtils.FormatInternalDate(date);
 
 			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
 		}

--- a/UnitTests/Net/Imap/ImapUtilsTests.cs
+++ b/UnitTests/Net/Imap/ImapUtilsTests.cs
@@ -4292,7 +4292,7 @@ namespace UnitTests.Net.Imap {
 		{
 			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
 
-			string formattedInternalDate = ImapUtils.FormatInternalDate(date);
+			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
 
 			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
 		}
@@ -4306,7 +4306,7 @@ namespace UnitTests.Net.Imap {
 		{
 			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
 
-			string formattedInternalDate = ImapUtils.FormatInternalDate(date);
+			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
 
 			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
 		}
@@ -4317,7 +4317,7 @@ namespace UnitTests.Net.Imap {
 		{
 			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
 
-			string formattedInternalDate = ImapUtils.FormatInternalDate(date);
+			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
 
 			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
 		}
@@ -4329,7 +4329,7 @@ namespace UnitTests.Net.Imap {
 		{
 			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
 
-			string formattedInternalDate = ImapUtils.FormatInternalDate(date);
+			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
 
 			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
 		}

--- a/UnitTests/Net/Imap/ImapUtilsTests.cs
+++ b/UnitTests/Net/Imap/ImapUtilsTests.cs
@@ -4272,7 +4272,7 @@ namespace UnitTests.Net.Imap {
 							Assert.Fail ($"Parsing LIST response failed: {ex}");
 							return;
 						}
-						
+
 						var token = await engine.ReadTokenAsync (CancellationToken.None);
 						Assert.That (token.Type, Is.EqualTo (ImapTokenType.Eoln), $"Expected new-line, but got: {token}");
 

--- a/UnitTests/Net/Imap/ImapUtilsTests.cs
+++ b/UnitTests/Net/Imap/ImapUtilsTests.cs
@@ -4272,7 +4272,7 @@ namespace UnitTests.Net.Imap {
 							Assert.Fail ($"Parsing LIST response failed: {ex}");
 							return;
 						}
-
+						
 						var token = await engine.ReadTokenAsync (CancellationToken.None);
 						Assert.That (token.Type, Is.EqualTo (ImapTokenType.Eoln), $"Expected new-line, but got: {token}");
 
@@ -4281,6 +4281,54 @@ namespace UnitTests.Net.Imap {
 					}
 				}
 			}
+		}
+
+		[Test]
+		[TestCase (2023, 5, 16, 12, 30, 45, -2, 0, "16-May-2023 12:30:45 -0200")]   // Tuesday
+		[TestCase (2023, 5, 17, 12, 30, 45, -1, 0, "17-May-2023 12:30:45 -0100")]   // Wednesday
+		public void TestFormatInternalDateNegativeOffsets (int year, int month, int day, int hour, int minute, int second, int offsetHours, int offsetMinutes, string expected)
+		{
+			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
+
+			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
+
+			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
+		}
+
+		[Test]
+		[TestCase (2023, 5, 18, 12, 30, 45, 1, 0, "18-May-2023 12:30:45 +0100")]   // Thursday
+		[TestCase (2023, 5, 19, 12, 30, 45, 4, 30, "19-May-2023 12:30:45 +0430")]  // Friday
+		[TestCase (2023, 5, 20, 12, 30, 45, 9, 30, "20-May-2023 12:30:45 +0930")]  // Saturday
+		[TestCase (2023, 5, 21, 12, 30, 45, 12, 0, "21-May-2023 12:30:45 +1200")]  // Sunday
+		public void TestFormatInternalDatePositiveOffsets (int year, int month, int day, int hour, int minute, int second, int offsetHours, int offsetMinutes, string expected)
+		{
+			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
+
+			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
+
+			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
+		}
+
+		[Test]
+		[TestCase (2023, 5, 22, 12, 30, 45, 0, 0, "22-May-2023 12:30:45 +0000")]  // Monday
+		public void TestFormatInternalDateZeroOffset (int year, int month, int day, int hour, int minute, int second, int offsetHours, int offsetMinutes, string expected)
+		{
+			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
+
+			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
+
+			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
+		}
+
+		[Test]
+		[TestCase (2023, 5, 23, 23, 59, 59, 2, 30, "23-May-2023 23:59:59 +0230")]  // Tuesday
+		public void TestFormatInternalDateEdgeCases (int year, int month, int day, int hour, int minute, int second, int offsetHours, int offsetMinutes, string expected)
+		{
+			var date = new DateTimeOffset (year, month, day, hour, minute, second, new TimeSpan (offsetHours, offsetMinutes, 0));
+
+			string formattedInternalDate = ImapUtils.FormatInternalDate (date);
+
+			Assert.That (formattedInternalDate, Is.EqualTo (expected), $"Expected {expected} but got {formattedInternalDate} for date {date}.");
 		}
 	}
 }


### PR DESCRIPTION
# First of all
First of all, thank you very much for your work on MailKit. I'm very pleased to have the opportunity to contribute to it !
Now, let's see what I found 😃.

# Issue
The `FormatInternalDate` method has a bug when handling time zones with negative offsets where the minutes component was non-zero. This resulted in incorrectly formatted outputs. Specifically, the method produced an invalid format with an extra negative sign for the minutes part. Examples of the incorrect outputs included:

```
Expected: 14-May-2023 12:30:45 -0430
But was: 14-May-2023 12:30:45 -04-30

Expected: 15-May-2023 12:30:45 -0330
But was: 15-May-2023 12:30:45 -03-30
```

These incorrect outputs are associated with time zones such as:
- Venezuela Standard Time (VET), which is UTC-04:30.
- Newfoundland Standard Time (NST), which is UTC-03:30.

# Fix
To address this issue, I formatted the time zone offset beforehand to ensure the correct inclusion of the sign and the proper formatting of hours and minutes in an invariant culture way. Along the process, I also created unit tests that confirm that the fix does not introduce regressions.

