### PR TITLE
Adjust ImapFolder.Create(Async) to document ArgumentException fully

### DIFF
--- a/MailKit/Net/Imap/ImapFolder.cs
+++ b/MailKit/Net/Imap/ImapFolder.cs
@@ -907,7 +907,7 @@ namespace MailKit.Net.Imap {
 		/// <paramref name="name"/> is <c>null</c>.
 		/// </exception>
 		/// <exception cref="System.ArgumentException">
-		/// <paramref name="name"/> is empty.
+		/// <paramref name="name"/> is empty or invalid.
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
 		/// The <see cref="ImapClient"/> has been disposed.
@@ -954,7 +954,7 @@ namespace MailKit.Net.Imap {
 		/// <paramref name="name"/> is <c>null</c>.
 		/// </exception>
 		/// <exception cref="System.ArgumentException">
-		/// <paramref name="name"/> is empty.
+		/// <paramref name="name"/> is empty or invalid.
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
 		/// The <see cref="ImapClient"/> has been disposed.
@@ -1061,7 +1061,7 @@ namespace MailKit.Net.Imap {
 		/// <para><paramref name="specialUses"/> is <c>null</c>.</para>
 		/// </exception>
 		/// <exception cref="System.ArgumentException">
-		/// <paramref name="name"/> is empty.
+		/// <paramref name="name"/> is empty or invalid.
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
 		/// The <see cref="ImapClient"/> has been disposed.
@@ -1113,7 +1113,7 @@ namespace MailKit.Net.Imap {
 		/// <para><paramref name="specialUses"/> is <c>null</c>.</para>
 		/// </exception>
 		/// <exception cref="System.ArgumentException">
-		/// <paramref name="name"/> is empty.
+		/// <paramref name="name"/> is empty or invalid.
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
 		/// The <see cref="ImapClient"/> has been disposed.


### PR DESCRIPTION
ArgumentException is apparently not only thrown when the `name` is empty, but also when the server rejects it, because it e.g. has a directory separator char in it.

See https://stackoverflow.com/questions/78844815/how-to-create-or-get-folders-in-mailkit-with-multiple-sub-folders-when-they-ar/78844857#78844857 for details.