### PR TITLE
docs: clarify/add the recommendation to set AutoSubmitted if needed

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1124,6 +1124,8 @@ the same way you'd create any other message. There are only a few slight differe
 3. You will want to copy the original message's `References` header into the reply message's
    `References` header and then append the original message's `Message-Id` header.
 4. You will probably want to "quote" the original message's text in the reply.
+5. In case you are doing an automatic reply, you should additionally follow [RFC3834](https://www.rfc-editor.org/rfc/rfc3834)
+   and set the `Auto-Submitted` value to `auto-replied`.
 
 If this logic were to be expressed in code, it might look something like this:
 
@@ -1162,6 +1164,9 @@ public static MimeMessage Reply (MimeMessage message, MailboxAddress from, bool 
             reply.References.Add (id);
         reply.References.Add (message.MessageId);
     }
+
+    // in case of an automatic reply clarify this for the receiver systems e.g. to avoid (infinite) mail loops
+    reply.Headers.Add(HeaderId.AutoSubmitted, "auto-replied");
 
     // quote the original message text
     using (var quoted = new StringWriter ()) {

--- a/FAQ.md
+++ b/FAQ.md
@@ -1124,7 +1124,7 @@ the same way you'd create any other message. There are only a few slight differe
 3. You will want to copy the original message's `References` header into the reply message's
    `References` header and then append the original message's `Message-Id` header.
 4. You will probably want to "quote" the original message's text in the reply.
-5. In case you are doing an automatic reply, you should additionally follow [RFC3834](https://www.rfc-editor.org/rfc/rfc3834)
+5. If you are generating an automatic reply, you should also follow [RFC3834](https://www.rfc-editor.org/rfc/rfc3834)
    and set the `Auto-Submitted` value to `auto-replied`.
 
 If this logic were to be expressed in code, it might look something like this:
@@ -1165,8 +1165,8 @@ public static MimeMessage Reply (MimeMessage message, MailboxAddress from, bool 
         reply.References.Add (message.MessageId);
     }
 
-    // in case of an automatic reply clarify this for the receiver systems e.g. to avoid (infinite) mail loops
-    reply.Headers.Add(HeaderId.AutoSubmitted, "auto-replied");
+    // if this is an automatic reply, be sure to specify this using the Auto-Submitted header in order to avoid (infinite) mail loops
+    reply.Headers.Add (HeaderId.AutoSubmitted, "auto-replied");
 
     // quote the original message text
     using (var quoted = new StringWriter ()) {


### PR DESCRIPTION
IMHO, many people using this lib may use it to automatically send replies. Sure, some may have some human in the loop, but we can assume that.

As such, IMHO; the FAQ should point that out.

Related to https://github.com/jstedfast/MimeKit/issues/938 of course and there are plenty of more headers to set in such a case, but it feels like this was the most standardized one and in any case the minimal one to do?

Also, the FAQ entry is about replying, so the header value does exactly reflect that. If you want to suppress responses or so, that may be an additional requirement.

I just want to minimize the amount of systems not following the spec and ignoring such an important thing. 🙃 