### PR TITLE
Fix typos

### DIFF
--- a/Documentation/Content/Frequently-Asked-Questions.aml
+++ b/Documentation/Content/Frequently-Asked-Questions.aml
@@ -184,7 +184,7 @@
             </code>
             <para>
               The downside of the above example is that it requires hard-coding known values for "trusted" mail server
-              certificates which can quickly become unweildy to deal with if your program is meant to be used with
+              certificates which can quickly become unwieldy to deal with if your program is meant to be used with
               a wide range of mail servers.
             </para>
             <para>
@@ -823,7 +823,7 @@ message.WriteTo (options, stream);
           The method variant that has a
           <codeEntityReference>T:MimeKit.Cryptography.DigitalSignatureCollection</codeEntityReference>
           output parameter is useful in cases where the encrypted PGP blurb is also digitally signed,
-          allowing you to get your hands on the list of digitial signatures in order for you to verify
+          allowing you to get your hands on the list of digital signatures in order for you to verify
           each of them.
         </para>
         <para>

--- a/Documentation/Content/Working-With-Messages.aml
+++ b/Documentation/Content/Working-With-Messages.aml
@@ -11,7 +11,7 @@
     -->
 
     <introduction>
-      <para>MimeKit provies a number of ways to get the data you want from a message.</para>
+      <para>MimeKit provides a number of ways to get the data you want from a message.</para>
       <autoOutline />
     </introduction>
 

--- a/Documentation/Content/Working-With-SMime.aml
+++ b/Documentation/Content/Working-With-SMime.aml
@@ -22,7 +22,7 @@
           database to use for certificate storage.
         </para>
         <para>
-          If you are targetting any of the <application>Xamarin</application> platforms
+          If you are targeting any of the <application>Xamarin</application> platforms
           (or Linux), you won't need to do anything (although you certainly can if you want to)
           because, by default, MimeKit will automatically use the
           <application>Mono.Data.Sqlite</application> binding to
@@ -124,7 +124,7 @@
         </para>
         <code language="c#" source="Examples\SMimeExamples.cs" region="MultipartSignWithKey"/>
         <para>
-          You can also choose to digitially sign a
+          You can also choose to digitally sign a
           <codeEntityReference>T:MimeKit.MimeEntity</codeEntityReference> using the
           <literal>application/pkcs7-mime</literal> format using
           <codeEntityReference autoUpgrade="true" qualifyHint="true">

--- a/Documentation/Examples/ArcVerifierExample.cs
+++ b/Documentation/Examples/ArcVerifierExample.cs
@@ -69,7 +69,7 @@ namespace ArcVerifierExample
                     return DnsLookup (domain, selector, cancellationToken);
             }
 
-            throw new NotSupportedException (string.Format ("{0} does not include any suported lookup methods.", methods));
+            throw new NotSupportedException (string.Format ("{0} does not include any supported lookup methods.", methods));
         }
 
         public Task<AsymmetricKeyParameter> LocatePublicKeyAsync (string methods, string domain, string selector, CancellationToken cancellationToken = default (CancellationToken))

--- a/Documentation/Examples/DkimVerifierExample.cs
+++ b/Documentation/Examples/DkimVerifierExample.cs
@@ -69,7 +69,7 @@ namespace DkimVerifierExample
                     return DnsLookup (domain, selector, cancellationToken);
             }
 
-            throw new NotSupportedException (string.Format ("{0} does not include any suported lookup methods.", methods));
+            throw new NotSupportedException (string.Format ("{0} does not include any supported lookup methods.", methods));
         }
 
         public Task<AsymmetricKeyParameter> LocatePublicKeyAsync (string methods, string domain, string selector, CancellationToken cancellationToken = default (CancellationToken))

--- a/Documentation/Examples/ImapExamples.cs
+++ b/Documentation/Examples/ImapExamples.cs
@@ -148,7 +148,7 @@ namespace MailKit.Examples {
 				// list the folders under the first personal namespace
 				var subfolders = personal.GetSubfolders ();
 
-				Console.WriteLine ("The list of folders that are direct children of the first personmal namespace:");
+				Console.WriteLine ("The list of folders that are direct children of the first personal namespace:");
 				foreach (var folder in subfolders)
 					Console.WriteLine ($"* {folder.Name}");
 

--- a/Documentation/Examples/ParameterExamples.cs
+++ b/Documentation/Examples/ParameterExamples.cs
@@ -11,7 +11,7 @@ namespace MimeKit.Examples
             #region OverrideAllParameterEncodings
             // Some versions of Outlook expect the rfc2047 style of encoding of parameter values.
             foreach (var parameter in part.ContentDisposition.Parameters)
-                parameter.EncodingMehod = ParameerEncodngMethod.Rfc2047;
+                parameter.EncodingMethod = ParameterEncodingMethod.Rfc2047;
             #endregion OverrideAllParameterEncodings
         }
 
@@ -20,7 +20,7 @@ namespace MimeKit.Examples
             #region OverrideFileNameParameterEncoding
             // Some versions of Outlook expect the rfc2047 style of encoding for the filename parameter value.
             if (part.ContentDisposition.Parameters.TryGetValue ("filename", out var parameter))
-                parameter.EncodingMehod = ParameerEncodngMethod.Rfc2047;
+                parameter.EncodingMethod = ParameterEncodingMethod.Rfc2047;
             #endregion OverrideFileNameParameterEncoding
         }
     }

--- a/FAQ.md
+++ b/FAQ.md
@@ -24,7 +24,7 @@
 * [How can I save attachments?](#save-attachments)
 * [How can I get the email addresses in the From, To, and Cc headers?](#address-headers)
 * [Why do attachments with unicode filenames appear as "ATT0####.dat" in Outlook?](#untitled-attachments)
-* [How can I decrypt PGP messages that are embedded in the main message text?](#decyrpt-inline-pgp)
+* [How can I decrypt PGP messages that are embedded in the main message text?](#decrypt-inline-pgp)
 * [How can I reply to a message?](#reply-message)
 * [How can I forward a message?](#forward-message)
 * [Why does text show up garbled in my ASP.NET Core / .NET Core / .NET 5 app?](#garbled-text)
@@ -59,7 +59,7 @@ Yes. MimeKit and MailKit are both completely free and open source. They are both
 In .NET Core, Microsoft decided to split out the non-Unicode text encodings into a separate NuGet package called
 [System.Text.Encoding.CodePages](https://www.nuget.org/packages/System.Text.Encoding.CodePages).
 
-MimeKit already pulls in a reference to this NuGet package, so you shsouldn't need to add a reference to it in
+MimeKit already pulls in a reference to this NuGet package, so you shouldn't need to add a reference to it in
 your project. That said, you will still need to register the encoding provider. It is recommended that you add
 the following line of code to your program initialization (e.g. the beginning of your program's Main() method):
 
@@ -193,7 +193,7 @@ bool MyServerCertificateValidationCallback (object sender, X509Certificate certi
 ```
 
 The downside of the above example is that it requires hard-coding known values for "trusted" mail server
-certificates which can quickly become unweildy to deal with if your program is meant to be used with
+certificates which can quickly become unwieldy to deal with if your program is meant to be used with
 a wide range of mail servers.
 
 The best approach would be to prompt the user with a dialog explaining that the certificate is
@@ -1031,7 +1031,7 @@ foreach (var param in attachment.ContentDisposition.Parameters) {
 }
 ```
 
-### <a id="decyrpt-inline-pgp">Q: How can I decrypt PGP messages that are embedded in the main message text?</a>
+### <a id="decrypt-inline-pgp">Q: How can I decrypt PGP messages that are embedded in the main message text?</a>
 
 Some PGP-enabled mail clients, such as Thunderbird, embed encrypted PGP blurbs within the `text/plain` body
 of the message rather than using the PGP/MIME format that MimeKit prefers.
@@ -1088,7 +1088,7 @@ public Stream GetDecryptedStream (Stream encryptedData)
 ```
 
 The first variant is useful in cases where the encrypted PGP blurb is also digitally signed, allowing you to get
-your hands on the list of digitial signatures in order for you to verify each of them.
+your hands on the list of digital signatures in order for you to verify each of them.
 
 To decrypt the content of the message, you'll want to locate the `TextPart` (in this case, it'll just be
 `message.Body`) and then do this:
@@ -1671,7 +1671,7 @@ folder.RemoveFlags (uids, MessageFlags.Seen, true);
 
 ### <a id="imap-folder-resync">Q: How can I re-synchronize the cache for an IMAP folder?</a>
 
-Assuming your IMAP server does not support the `QRESYNC` extension (which simplifies this proceedure a ton),
+Assuming your IMAP server does not support the `QRESYNC` extension (which simplifies this procedure a ton),
 here is some simple code to illustrate how to go about re-synchronizing your cache with the remote IMAP
 server.
 

--- a/MailKit/AnnotationEntry.cs
+++ b/MailKit/AnnotationEntry.cs
@@ -1,5 +1,5 @@
 ﻿//
-// Annotationentry.cs
+// AnnotationEntry.cs
 //
 // Author: Jeffrey Stedfast <jestedfa@microsoft.com>
 //

--- a/MailKit/CompressedStream.cs
+++ b/MailKit/CompressedStream.cs
@@ -94,9 +94,9 @@ namespace MailKit {
 		}
 
 		/// <summary>
-		/// Gets or sets a value, in miliseconds, that determines how long the stream will attempt to read before timing out.
+		/// Gets or sets a value, in milliseconds, that determines how long the stream will attempt to read before timing out.
 		/// </summary>
-		/// <returns>A value, in miliseconds, that determines how long the stream will attempt to read before timing out.</returns>
+		/// <returns>A value, in milliseconds, that determines how long the stream will attempt to read before timing out.</returns>
 		/// <value>The read timeout.</value>
 		public override int ReadTimeout {
 			get { return InnerStream.ReadTimeout; }
@@ -104,9 +104,9 @@ namespace MailKit {
 		}
 
 		/// <summary>
-		/// Gets or sets a value, in miliseconds, that determines how long the stream will attempt to write before timing out.
+		/// Gets or sets a value, in milliseconds, that determines how long the stream will attempt to write before timing out.
 		/// </summary>
-		/// <returns>A value, in miliseconds, that determines how long the stream will attempt to write before timing out.</returns>
+		/// <returns>A value, in milliseconds, that determines how long the stream will attempt to write before timing out.</returns>
 		/// <value>The write timeout.</value>
 		public override int WriteTimeout {
 			get { return InnerStream.WriteTimeout; }
@@ -171,7 +171,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -232,7 +232,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -292,7 +292,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -343,7 +343,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">

--- a/MailKit/DeliveryStatusNotification.cs
+++ b/MailKit/DeliveryStatusNotification.cs
@@ -33,7 +33,7 @@ namespace MailKit {
 	/// <remarks>
 	/// A set of flags that may be bitwise-or'd together to specify
 	/// when a delivery status notification should be sent for a
-	/// particlar recipient.
+	/// particular recipient.
 	/// </remarks>
 	/// <example>
 	/// <code language="c#" source="Examples\SmtpExamples.cs" region="DeliveryStatusNotification"/>

--- a/MailKit/DuplexStream.cs
+++ b/MailKit/DuplexStream.cs
@@ -108,9 +108,9 @@ namespace MailKit {
 		}
 
 		/// <summary>
-		/// Gets or sets a value, in miliseconds, that determines how long the stream will attempt to read before timing out.
+		/// Gets or sets a value, in milliseconds, that determines how long the stream will attempt to read before timing out.
 		/// </summary>
-		/// <returns>A value, in miliseconds, that determines how long the stream will attempt to read before timing out.</returns>
+		/// <returns>A value, in milliseconds, that determines how long the stream will attempt to read before timing out.</returns>
 		/// <value>The read timeout.</value>
 		public override int ReadTimeout {
 			get { return InputStream.ReadTimeout; }
@@ -118,9 +118,9 @@ namespace MailKit {
 		}
 
 		/// <summary>
-		/// Gets or sets a value, in miliseconds, that determines how long the stream will attempt to write before timing out.
+		/// Gets or sets a value, in milliseconds, that determines how long the stream will attempt to write before timing out.
 		/// </summary>
-		/// <returns>A value, in miliseconds, that determines how long the stream will attempt to write before timing out.</returns>
+		/// <returns>A value, in milliseconds, that determines how long the stream will attempt to write before timing out.</returns>
 		/// <value>The write timeout.</value>
 		public override int WriteTimeout {
 			get { return OutputStream.WriteTimeout; }
@@ -185,7 +185,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -219,7 +219,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -250,7 +250,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -286,7 +286,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">

--- a/MailKit/FolderNamespaceCollection.cs
+++ b/MailKit/FolderNamespaceCollection.cs
@@ -116,12 +116,12 @@ namespace MailKit {
 		}
 
 		/// <summary>
-		/// Removes the first occurance of the specified namespace.
+		/// Removes the first occurrence of the specified namespace.
 		/// </summary>
 		/// <remarks>
-		/// Removes the first occurance of the specified namespace.
+		/// Removes the first occurrence of the specified namespace.
 		/// </remarks>
-		/// <returns><value>true</value> if the frst occurance of the specified
+		/// <returns><value>true</value> if the first occurrence of the specified
 		/// namespace was removed; otherwise <value>false</value>.</returns>
 		/// <param name="namespace">The namespace.</param>
 		/// <exception cref="System.ArgumentNullException">

--- a/MailKit/IMailFolder.cs
+++ b/MailKit/IMailFolder.cs
@@ -831,7 +831,7 @@ namespace MailKit {
 		void SetAccessRights (string name, AccessRights rights, CancellationToken cancellationToken = default);
 
 		/// <summary>
-		/// Asynchronously set the access rights for the sepcified identity.
+		/// Asynchronously set the access rights for the specified identity.
 		/// </summary>
 		/// <remarks>
 		/// Asynchronously sets the access rights for the specified identity.
@@ -2603,7 +2603,7 @@ namespace MailKit {
 		/// Search the subset of UIDs in the folder for messages matching the specified query.
 		/// </summary>
 		/// <remarks>
-		/// Searches the fsubset of UIDs in the folder for messages matching the specified query,
+		/// Searches the subset of UIDs in the folder for messages matching the specified query,
 		/// returning only the specified search results.
 		/// </remarks>
 		/// <returns>The search results.</returns>
@@ -2617,7 +2617,7 @@ namespace MailKit {
 		/// Asynchronously search the subset of UIDs in the folder for messages matching the specified query.
 		/// </summary>
 		/// <remarks>
-		/// Asynchronously searches the fsubset of UIDs in the folder for messages matching the specified query,
+		/// Asynchronously searches the subset of UIDs in the folder for messages matching the specified query,
 		/// returning only the specified search results.
 		/// </remarks>
 		/// <returns>The search results.</returns>
@@ -2899,8 +2899,8 @@ namespace MailKit {
 		/// <note type="note">The <a href="Overload_MailKit_IMailFolder_Fetch.htm">Fetch</a>
 		/// methods will return a list of all message summaries that any information was
 		/// retrieved for, regardless of whether or not all of the requested items were fetched,
-		/// therefore there may be a discrepency between the number of times this event is
-		/// emitetd and the number of summary items returned from the Fetch method.</note>
+		/// therefore there may be a discrepancy between the number of times this event is
+		/// emitted and the number of summary items returned from the Fetch method.</note>
 		/// </remarks>
 		event EventHandler<MessageSummaryFetchedEventArgs> MessageSummaryFetched;
 

--- a/MailKit/IMailFolderFetchExtensions.cs
+++ b/MailKit/IMailFolderFetchExtensions.cs
@@ -33,10 +33,10 @@ using MimeKit;
 
 namespace MailKit {
 	/// <summary>
-	/// Extension methods for <see cref="IMailFolder"/> that provide backwards API compatability.
+	/// Extension methods for <see cref="IMailFolder"/> that provide backwards API compatibility.
 	/// </summary>
 	/// <remarks>
-	/// Extension methods for <see cref="IMailFolder"/> that provide backwards API compatability.
+	/// Extension methods for <see cref="IMailFolder"/> that provide backwards API compatibility.
 	/// </remarks>
 	public static partial class IMailFolderExtensions
 	{

--- a/MailKit/IMailService.cs
+++ b/MailKit/IMailService.cs
@@ -166,7 +166,7 @@ namespace MailKit {
 		/// Get the authentication mechanisms supported by the message service.
 		/// </summary>
 		/// <remarks>
-		/// The authentication mechanisms are queried durring the
+		/// The authentication mechanisms are queried during the
 		/// <a href="Overload_MailKit_IMailService_Connect.htm">Connect</a> method.
 		/// </remarks>
 		/// <value>The supported authentication mechanisms.</value>

--- a/MailKit/IMailSpool.cs
+++ b/MailKit/IMailSpool.cs
@@ -33,10 +33,10 @@ using MimeKit;
 
 namespace MailKit {
 	/// <summary>
-	/// An interface for retreiving messages from a spool.
+	/// An interface for retrieving messages from a spool.
 	/// </summary>
 	/// <remarks>
-	/// <para>An interface for retreiving messages from a spool.</para>
+	/// <para>An interface for retrieving messages from a spool.</para>
 	/// <para>Implemented by <see cref="MailKit.Net.Pop3.Pop3Client"/>.</para>
 	/// </remarks>
 	public interface IMailSpool : IMailService, IEnumerable<MimeMessage>

--- a/MailKit/IMailStore.cs
+++ b/MailKit/IMailStore.cs
@@ -31,10 +31,10 @@ using System.Collections.Generic;
 
 namespace MailKit {
 	/// <summary>
-	/// An interface for retreiving messages from a message store.
+	/// An interface for retrieving messages from a message store.
 	/// </summary>
 	/// <remarks>
-	/// <para>An interface for retreiving messages from a message store.</para>
+	/// <para>An interface for retrieving messages from a message store.</para>
 	/// <para>Implemented by <see cref="MailKit.Net.Imap.ImapClient"/>.</para>
 	/// </remarks>
 	public interface IMailStore : IMailService

--- a/MailKit/IMessageSummary.cs
+++ b/MailKit/IMessageSummary.cs
@@ -44,7 +44,7 @@ namespace MailKit {
 	/// <a href="Overload_MailKit_IMailFolder_FetchAsync.htm">FetchAsync</a> methods
 	/// return lists of <see cref="IMessageSummary"/> items.</para>
 	/// <para>The properties of the <see cref="IMessageSummary"/> that will be available
-	/// depend on the <see cref="MessageSummaryItems"/> passed to the aformentioned method.</para>
+	/// depend on the <see cref="MessageSummaryItems"/> passed to the aforementioned method.</para>
 	/// </remarks>
 	public interface IMessageSummary
 	{

--- a/MailKit/IProtocolLogger.cs
+++ b/MailKit/IProtocolLogger.cs
@@ -83,7 +83,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -111,7 +111,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">

--- a/MailKit/IStoreRequest.cs
+++ b/MailKit/IStoreRequest.cs
@@ -40,7 +40,7 @@ namespace MailKit {
 		/// <para>Gets or sets the mod-sequence value that indicates the last known state of the message(s) being updated.</para>
 		/// <para>If this property is set, only messages that have not had their flags modified since the specified mod-sequence
 		/// state will have their flags updated by the <a href="Overload_MailKit_IMailFolder_Store.htm">Store</a>
-		/// or <a href="Overload_MailKit_IMailFolder_StoreAsync.htm">StoreAsync</a> mnethods.</para>
+		/// or <a href="Overload_MailKit_IMailFolder_StoreAsync.htm">StoreAsync</a> methods.</para>
 		/// </remarks>
 		/// <value>The mod-sequence value that indicates the last known state of the message(s) being updated.</value>
 		ulong? UnchangedSince { get; set; }

--- a/MailKit/MailFolder.cs
+++ b/MailKit/MailFolder.cs
@@ -8523,7 +8523,7 @@ namespace MailKit {
 		/// Search the subset of UIDs in the folder for messages matching the specified query.
 		/// </summary>
 		/// <remarks>
-		/// Searches the fsubset of UIDs in the folder for messages matching the specified query,
+		/// Searches the subset of UIDs in the folder for messages matching the specified query,
 		/// returning only the specified search results.
 		/// </remarks>
 		/// <returns>The search results.</returns>
@@ -8584,7 +8584,7 @@ namespace MailKit {
 		/// Asynchronously search the subset of UIDs in the folder for messages matching the specified query.
 		/// </summary>
 		/// <remarks>
-		/// Asynchronously searches the fsubset of UIDs in the folder for messages matching the specified query,
+		/// Asynchronously searches the subset of UIDs in the folder for messages matching the specified query,
 		/// returning only the specified search results.
 		/// </remarks>
 		/// <returns>The search results.</returns>

--- a/MailKit/MessageSummary.cs
+++ b/MailKit/MessageSummary.cs
@@ -46,7 +46,7 @@ namespace MailKit {
 	/// <a href="Overload_MailKit_IMailFolder_FetchAsync.htm">FetchAsync</a> methods
 	/// return lists of <see cref="IMessageSummary"/> items.</para>
 	/// <para>The properties of the <see cref="MessageSummary"/> that will be available
-	/// depend on the <see cref="MessageSummaryItems"/> passed to the aformentioned method.</para>
+	/// depend on the <see cref="MessageSummaryItems"/> passed to the aforementioned method.</para>
 	/// </remarks>
 	public class MessageSummary : IMessageSummary
 	{
@@ -226,7 +226,7 @@ namespace MailKit {
 					text = multipart.BodyParts[i] as BodyPartText;
 
 					// Look for the first non-attachment text part (realistically, the body text will
-					// preceed any attachments, but I'm not sure we can rely on that assumption).
+					// precede any attachments, but I'm not sure we can rely on that assumption).
 					if (text != null && !text.IsAttachment) {
 						if (html ? text.IsHtml : text.IsPlain) {
 							body = text;

--- a/MailKit/MessageSummaryItems.cs
+++ b/MailKit/MessageSummaryItems.cs
@@ -46,7 +46,7 @@ namespace MailKit {
 
 		/// <summary>
 		/// <para>Fetch the <see cref="IMessageSummary.Annotations"/>.</para>
-		/// <para>Fetches all <c>ANNOATION</c> values as defined in
+		/// <para>Fetches all <c>ANNOTATION</c> values as defined in
 		/// <a href="https://tools.ietf.org/html/rfc5257">rfc5257</a>.</para>
 		/// </summary>
 		Annotations    = 1 << 0,

--- a/MailKit/Net/Imap/ImapClient.cs
+++ b/MailKit/Net/Imap/ImapClient.cs
@@ -245,7 +245,7 @@ namespace MailKit.Net.Imap {
 		/// <note type="note">This method's purpose is to allow subclassing <see cref="ImapFolder"/>.</note>
 		/// </remarks>
 		/// <returns>The IMAP folder instance.</returns>
-		/// <param name="args">The constructior arguments.</param>
+		/// <param name="args">The constructor arguments.</param>
 		/// <exception cref="System.ArgumentNullException">
 		/// <paramref name="args"/> is <c>null</c>.
 		/// </exception>

--- a/MailKit/Net/Imap/ImapEngine.cs
+++ b/MailKit/Net/Imap/ImapEngine.cs
@@ -195,7 +195,7 @@ namespace MailKit.Net.Imap {
 		/// Get the authentication mechanisms supported by the IMAP server.
 		/// </summary>
 		/// <remarks>
-		/// The authentication mechanisms are queried durring the
+		/// The authentication mechanisms are queried during the
 		/// <see cref="Connect"/> or <see cref="ConnectAsync"/> methods.
 		/// </remarks>
 		/// <value>The authentication mechanisms.</value>
@@ -702,7 +702,7 @@ namespace MailKit.Net.Imap {
 		}
 
 		/// <summary>
-		/// Takes posession of the <see cref="ImapStream"/> and reads the greeting.
+		/// Takes possession of the <see cref="ImapStream"/> and reads the greeting.
 		/// </summary>
 		/// <param name="stream">The IMAP stream.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
@@ -763,7 +763,7 @@ namespace MailKit.Net.Imap {
 		}
 
 		/// <summary>
-		/// Takes posession of the <see cref="ImapStream"/> and reads the greeting.
+		/// Takes possession of the <see cref="ImapStream"/> and reads the greeting.
 		/// </summary>
 		/// <param name="stream">The IMAP stream.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
@@ -3320,7 +3320,7 @@ namespace MailKit.Net.Imap {
 		/// <summary>
 		/// Gets the cached folder.
 		/// </summary>
-		/// <returns><c>true</c> if the folder was retreived from the cache; otherwise, <c>false</c>.</returns>
+		/// <returns><c>true</c> if the folder was retrieved from the cache; otherwise, <c>false</c>.</returns>
 		/// <param name="encodedName">The encoded folder name.</param>
 		/// <param name="folder">The cached folder.</param>
 		public bool TryGetCachedFolder (string encodedName, out ImapFolder folder)
@@ -3632,7 +3632,7 @@ namespace MailKit.Net.Imap {
 			// Note: Some IMAP servers like ProtonMail respond to SPECIAL-USE LIST queries with BAD, so fall
 			// back to just issuing a standard LIST command and hope we get back some SPECIAL-USE attributes.
 			//
-			// See https://github.com/jstedfast/MailKit/issues/674 for dertails.
+			// See https://github.com/jstedfast/MailKit/issues/674 for details.
 			if (QuirksMode != ImapQuirksMode.ProtonMail)
 				command.Append ("(SPECIAL-USE) \"\" \"*\"");
 			else
@@ -4079,7 +4079,7 @@ namespace MailKit.Net.Imap {
 		/// </summary>
 		/// <returns><c>true</c> if the mailbox name is valid; otherwise, <c>false</c>.</returns>
 		/// <param name="mailboxName">The mailbox name.</param>
-		/// <param name="delim">The path delimeter.</param>
+		/// <param name="delim">The path delimiter.</param>
 		public static bool IsValidMailboxName (string mailboxName, char delim)
 		{
 			// From rfc6855:

--- a/MailKit/Net/Imap/ImapEventGroup.cs
+++ b/MailKit/Net/Imap/ImapEventGroup.cs
@@ -524,7 +524,7 @@ namespace MailKit.Net.Imap {
 		/// </summary>
 		/// <remarks>
 		/// <para>These notifications are sent if an affected mailbox name was created, deleted, or renamed.</para>
-		/// <para>As these notifications are received by the client, the apropriate will be emitted:
+		/// <para>As these notifications are received by the client, the appropriate will be emitted:
 		/// <see cref="MailStore.FolderCreated"/>, <see cref="IMailFolder.Deleted"/>, or
 		/// <see cref="IMailFolder.Renamed"/>, respectively.</para>
 		/// <note type="info">If the server supports <see cref="ImapCapabilities.Acl"/>, granting or revocation of the

--- a/MailKit/Net/Imap/ImapFolder.cs
+++ b/MailKit/Net/Imap/ImapFolder.cs
@@ -5557,7 +5557,7 @@ namespace MailKit.Net.Imap {
 		/// <see cref="Expunge(IList&lt;UniqueId&gt;,CancellationToken)"/> for more information about how a
 		/// subset of messages are expunged). Since the server could disconnect at any point between those 3
 		/// (or more) commands, it is advisable for clients to implement their own logic for moving messages when
-		/// the IMAP server does not support the MOVE command in order to better handle spontanious server
+		/// the IMAP server does not support the MOVE command in order to better handle spontaneous server
 		/// disconnects and other error conditions.</para>
 		/// </remarks>
 		/// <returns>The UID mapping of the messages in the destination folder, if available; otherwise an empty mapping.</returns>
@@ -5652,7 +5652,7 @@ namespace MailKit.Net.Imap {
 		/// <see cref="Expunge(IList&lt;UniqueId&gt;,CancellationToken)"/> for more information about how a
 		/// subset of messages are expunged). Since the server could disconnect at any point between those 3
 		/// (or more) commands, it is advisable for clients to implement their own logic for moving messages when
-		/// the IMAP server does not support the MOVE command in order to better handle spontanious server
+		/// the IMAP server does not support the MOVE command in order to better handle spontaneous server
 		/// disconnects and other error conditions.</para>
 		/// </remarks>
 		/// <returns>The UID mapping of the messages in the destination folder, if available; otherwise an empty mapping.</returns>
@@ -5922,7 +5922,7 @@ namespace MailKit.Net.Imap {
 		/// the messages will first be copied to the destination folder and then marked as \Deleted in the
 		/// originating folder. Since the server could disconnect at any point between those 2 operations, it
 		/// may be advisable to implement your own logic for moving messages in this case in order to better
-		/// handle spontanious server disconnects and other error conditions.</para>
+		/// handle spontaneous server disconnects and other error conditions.</para>
 		/// </remarks>
 		/// <param name="indexes">The indexes of the messages to move.</param>
 		/// <param name="destination">The destination folder.</param>
@@ -5990,7 +5990,7 @@ namespace MailKit.Net.Imap {
 		/// the messages will first be copied to the destination folder and then marked as \Deleted in the
 		/// originating folder. Since the server could disconnect at any point between those 2 operations, it
 		/// may be advisable to implement your own logic for moving messages in this case in order to better
-		/// handle spontanious server disconnects and other error conditions.</para>
+		/// handle spontaneous server disconnects and other error conditions.</para>
 		/// </remarks>
 		/// <returns>An awaitable task.</returns>
 		/// <param name="indexes">The indexes of the messages to move.</param>

--- a/MailKit/Net/Imap/ImapFolderFetch.cs
+++ b/MailKit/Net/Imap/ImapFolderFetch.cs
@@ -971,7 +971,7 @@ namespace MailKit.Net.Imap
 			// e.g. "UID CONVERT {0} (\"text/plain\" (\"charset\" \"utf-8\")) BINARY[{1}]<0.{2}>\r\n"
 			//
 			// This would allow us to more accurately fetch X number of characters because we wouldn't
-			// need to guestimate accounting for base64/quoted-printable decoding.
+			// need to guesstimate accounting for base64/quoted-printable decoding.
 
 			var command = string.Format (CultureInfo.InvariantCulture, "UID FETCH {0} (BODY.PEEK[{1}]<0.{2}>)\r\n", uids, specifier, octets);
 			var ic = new ImapCommand (Engine, cancellationToken, this, command);

--- a/MailKit/Net/Imap/ImapStream.cs
+++ b/MailKit/Net/Imap/ImapStream.cs
@@ -383,7 +383,7 @@ namespace MailKit.Net.Imap {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -443,7 +443,7 @@ namespace MailKit.Net.Imap {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -480,7 +480,7 @@ namespace MailKit.Net.Imap {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -1074,7 +1074,7 @@ namespace MailKit.Net.Imap {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -1149,7 +1149,7 @@ namespace MailKit.Net.Imap {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -1185,7 +1185,7 @@ namespace MailKit.Net.Imap {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">

--- a/MailKit/Net/Imap/ImapUtils.cs
+++ b/MailKit/Net/Imap/ImapUtils.cs
@@ -669,7 +669,7 @@ namespace MailKit.Net.Imap {
 
 			ImapEngine.AssertToken (token, ImapTokenType.CloseParen, format, token);
 
-			// parse the path delimeter
+			// parse the path delimiter
 			token = engine.ReadToken (cancellationToken);
 
 			delim = ParseFolderSeparator (token, format);
@@ -755,7 +755,7 @@ namespace MailKit.Net.Imap {
 
 			ImapEngine.AssertToken (token, ImapTokenType.CloseParen, format, token);
 
-			// parse the path delimeter
+			// parse the path delimiter
 			token = await engine.ReadTokenAsync (cancellationToken).ConfigureAwait (false);
 
 			delim = ParseFolderSeparator (token, format);
@@ -1719,7 +1719,7 @@ namespace MailKit.Net.Imap {
 						return true;
 					}
 
-					// Fall through and treat things nomrally.
+					// Fall through and treat things normally.
 				}
 
 				// We've got a string which normally means it's the first token of a mime-type.

--- a/MailKit/Net/Pop3/Pop3Engine.cs
+++ b/MailKit/Net/Pop3/Pop3Engine.cs
@@ -96,7 +96,7 @@ namespace MailKit.Net.Pop3 {
 		/// Gets the authentication mechanisms supported by the POP3 server.
 		/// </summary>
 		/// <remarks>
-		/// The authentication mechanisms are queried durring the
+		/// The authentication mechanisms are queried during the
 		/// <see cref="ConnectAsync(Pop3Stream,CancellationToken)"/> method.
 		/// </remarks>
 		/// <value>The authentication mechanisms.</value>
@@ -261,10 +261,10 @@ namespace MailKit.Net.Pop3 {
 		}
 
 		/// <summary>
-		/// Takes posession of the <see cref="Pop3Stream"/> and reads the greeting.
+		/// Takes possession of the <see cref="Pop3Stream"/> and reads the greeting.
 		/// </summary>
 		/// <remarks>
-		/// Takes posession of the <see cref="Pop3Stream"/> and reads the greeting.
+		/// Takes possession of the <see cref="Pop3Stream"/> and reads the greeting.
 		/// </remarks>
 		/// <param name="pop3">The pop3 stream.</param>
 		/// <param name="cancellationToken">The cancellation token</param>
@@ -279,10 +279,10 @@ namespace MailKit.Net.Pop3 {
 		}
 
 		/// <summary>
-		/// Takes posession of the <see cref="Pop3Stream"/> and reads the greeting.
+		/// Takes possession of the <see cref="Pop3Stream"/> and reads the greeting.
 		/// </summary>
 		/// <remarks>
-		/// Takes posession of the <see cref="Pop3Stream"/> and reads the greeting.
+		/// Takes possession of the <see cref="Pop3Stream"/> and reads the greeting.
 		/// </remarks>
 		/// <param name="pop3">The pop3 stream.</param>
 		/// <param name="cancellationToken">The cancellation token</param>

--- a/MailKit/Net/Pop3/Pop3Stream.cs
+++ b/MailKit/Net/Pop3/Pop3Stream.cs
@@ -138,7 +138,7 @@ namespace MailKit.Net.Pop3 {
 		/// Get whether or not the end of the raw data has been reached in <see cref="Pop3StreamMode.Data"/> mode.
 		/// </summary>
 		/// <remarks>
-		/// When reading the resonse to a command such as RETR, the end of the data is marked by line matching ".\r\n".
+		/// When reading the response to a command such as RETR, the end of the data is marked by line matching ".\r\n".
 		/// </remarks>
 		/// <value><c>true</c> if the end of the data has been reached; otherwise, <c>false</c>.</value>
 		public bool IsEndOfData {
@@ -446,7 +446,7 @@ namespace MailKit.Net.Pop3 {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -513,7 +513,7 @@ namespace MailKit.Net.Pop3 {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -550,7 +550,7 @@ namespace MailKit.Net.Pop3 {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -805,7 +805,7 @@ namespace MailKit.Net.Pop3 {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -886,7 +886,7 @@ namespace MailKit.Net.Pop3 {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -922,7 +922,7 @@ namespace MailKit.Net.Pop3 {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">

--- a/MailKit/Net/Smtp/SmtpClient.cs
+++ b/MailKit/Net/Smtp/SmtpClient.cs
@@ -286,7 +286,7 @@ namespace MailKit.Net.Smtp {
 		/// <para>Gets whether or not the <c>BDAT</c> command is preferred over the standard <c>DATA</c>
 		/// command.</para>
 		/// <para>The <c>BDAT</c> command is normally only used when the message being sent contains binary data
-		/// (e.g. one mor more MIME parts contains a <c>Content-Transfer-Encoding: binary</c> header). This
+		/// (e.g. one or more MIME parts contains a <c>Content-Transfer-Encoding: binary</c> header). This
 		/// option provides a way to override this behavior, forcing the <see cref="SmtpClient"/> to send
 		/// messages using the <c>BDAT</c> command instead of the <c>DATA</c> command even when it is not
 		/// necessary to do so.</para>

--- a/MailKit/Net/Smtp/SmtpCommandException.cs
+++ b/MailKit/Net/Smtp/SmtpCommandException.cs
@@ -175,7 +175,7 @@ namespace MailKit.Net.Smtp {
 		/// Get the error code which may provide additional information.
 		/// </summary>
 		/// <remarks>
-		/// The error code can be used to programatically deal with the
+		/// The error code can be used to programmatically deal with the
 		/// exception without necessarily needing to display the raw
 		/// exception message to the user.
 		/// </remarks>

--- a/MailKit/Net/Smtp/SmtpErrorCode.cs
+++ b/MailKit/Net/Smtp/SmtpErrorCode.cs
@@ -54,7 +54,7 @@ namespace MailKit.Net.Smtp {
 		/// <summary>
 		/// A recipient's mailbox address was not accepted. Check the
 		/// <see cref="SmtpCommandException.Mailbox"/> property for the
-		/// particular recipient mailbox that was not acccepted.
+		/// particular recipient mailbox that was not accepted.
 		/// </summary>
 		RecipientNotAccepted,
 

--- a/MailKit/Net/Smtp/SmtpStream.cs
+++ b/MailKit/Net/Smtp/SmtpStream.cs
@@ -325,7 +325,7 @@ namespace MailKit.Net.Smtp {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -381,7 +381,7 @@ namespace MailKit.Net.Smtp {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -415,7 +415,7 @@ namespace MailKit.Net.Smtp {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -781,7 +781,7 @@ namespace MailKit.Net.Smtp {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -862,7 +862,7 @@ namespace MailKit.Net.Smtp {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -898,7 +898,7 @@ namespace MailKit.Net.Smtp {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">

--- a/MailKit/PreviewOptions.cs
+++ b/MailKit/PreviewOptions.cs
@@ -38,7 +38,7 @@ namespace MailKit {
 		None,
 
 		/// <summary>
-		/// The preview text should only be fetched if the server has it intstantly available (cached).
+		/// The preview text should only be fetched if the server has it instantly available (cached).
 		/// </summary>
 		Lazy
 	}

--- a/MailKit/ProtocolLogger.cs
+++ b/MailKit/ProtocolLogger.cs
@@ -332,7 +332,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">
@@ -365,7 +365,7 @@ namespace MailKit {
 		/// <exception cref="System.ArgumentOutOfRangeException">
 		/// <para><paramref name="offset"/> is less than zero or greater than the length of <paramref name="buffer"/>.</para>
 		/// <para>-or-</para>
-		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes strting
+		/// <para>The <paramref name="buffer"/> is not large enough to contain <paramref name="count"/> bytes starting
 		/// at the specified <paramref name="offset"/>.</para>
 		/// </exception>
 		/// <exception cref="System.ObjectDisposedException">

--- a/MailKit/Search/OrderBy.cs
+++ b/MailKit/Search/OrderBy.cs
@@ -88,10 +88,10 @@ namespace MailKit.Search {
 		public static readonly OrderBy Arrival = new OrderBy (OrderByType.Arrival, SortOrder.Ascending);
 
 		/// <summary>
-		/// Sort results by arrival date in desending order.
+		/// Sort results by arrival date in descending order.
 		/// </summary>
 		/// <remarks>
-		/// Sort results by arrival date in desending order.
+		/// Sort results by arrival date in descending order.
 		/// </remarks>
 		public static readonly OrderBy ReverseArrival = new OrderBy (OrderByType.Arrival, SortOrder.Descending);
 

--- a/MailKit/Security/AuthenticationException.cs
+++ b/MailKit/Security/AuthenticationException.cs
@@ -46,7 +46,7 @@ namespace MailKit.Security {
 		/// Initializes a new instance of the <see cref="AuthenticationException"/> class.
 		/// </summary>
 		/// <remarks>
-		/// Creates a new <see cref="AuthenticationException"/> from the seriaized data.
+		/// Creates a new <see cref="AuthenticationException"/> from the serialized data.
 		/// </remarks>
 		/// <param name="info">The serialization info.</param>
 		/// <param name="context">The streaming context.</param>

--- a/MailKit/Security/SaslMechanism.cs
+++ b/MailKit/Security/SaslMechanism.cs
@@ -680,7 +680,7 @@ namespace MailKit.Security {
 			var builder = new StringBuilder (s.Length);
 			for (int i = 0; i < s.Length; i++) {
 				if (IsNonAsciiSpace (s[i])) {
-					// non-ASII space characters [StringPrep, C.1.2] that can be
+					// non-ASCII space characters [StringPrep, C.1.2] that can be
 					// mapped to SPACE (U+0020).
 					builder.Append (' ');
 				} else if (IsCommonlyMappedToNothing (s[i])) {

--- a/MailKit/Security/SslHandshakeException.cs
+++ b/MailKit/Security/SslHandshakeException.cs
@@ -44,7 +44,7 @@ namespace MailKit.Security
 	/// </summary>
 	/// <remarks>
 	/// <para>The exception that is thrown when there is an error during the SSL/TLS handshake.</para>
-	/// <para>When this exception occurrs, it typically means that the IMAP, POP3 or SMTP server that
+	/// <para>When this exception occurs, it typically means that the IMAP, POP3 or SMTP server that
 	/// you are connecting to is using an SSL certificate that is either expired or untrusted by
 	/// your system.</para>
 	/// <para>Often times, mail servers will use self-signed certificates instead of using a certificate
@@ -70,7 +70,7 @@ namespace MailKit.Security
 		/// Initializes a new instance of the <see cref="SslHandshakeException"/> class.
 		/// </summary>
 		/// <remarks>
-		/// Creates a new <see cref="SslHandshakeException"/> from the seriaized data.
+		/// Creates a new <see cref="SslHandshakeException"/> from the serialized data.
 		/// </remarks>
 		/// <param name="info">The serialization info.</param>
 		/// <param name="context">The streaming context.</param>

--- a/MailKit/UniqueIdRange.cs
+++ b/MailKit/UniqueIdRange.cs
@@ -43,7 +43,7 @@ namespace MailKit {
 	public class UniqueIdRange : IList<UniqueId>
 	{
 		/// <summary>
-		/// A <see cref="UniqueIdRange"/> that encompases all messages in the folder.
+		/// A <see cref="UniqueIdRange"/> that encompasses all messages in the folder.
 		/// </summary>
 		/// <remarks>
 		/// Represents the range of messages from <see cref="UniqueId.MinValue"/> to

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ foreach (var folder in personal.GetSubfolders (false))
     Console.WriteLine ("[folder] {0}", folder.Name);
 ```
 
-If the IMAP server supports the SPECIAL-USE or the XLIST (GMail) extension, you can get ahold of
+If the IMAP server supports the SPECIAL-USE or the XLIST (GMail) extension, you can get a hold of
 the pre-defined All, Drafts, Flagged (aka Important), Junk, Sent, Trash, etc folders like this:
 
 ```csharp

--- a/RFCs.md
+++ b/RFCs.md
@@ -9,7 +9,7 @@ The following IETF specifications define the IMAP, POP3 and SMTP protocols:
 * [1123](https://tools.ietf.org/html/rfc1123): Requirements for Internet Hosts -- Application and Support
 * [1225](https://tools.ietf.org/html/rfc1225): Post Office Protocol - Version 3 (Obsoletes rfc1081)
 * [1425](https://tools.ietf.org/html/rfc1425): SMTP Service Extensions
-* [1426](https://tools.ietf.org/html/rfc1426): SMTP Service Extension for 8bit-MIMEtransport
+* [1426](https://tools.ietf.org/html/rfc1426): SMTP Service Extension for 8bit-MIME transport
 * [1460](https://tools.ietf.org/html/rfc1460): Post Office Protocol - Version 3 (Obsoletes rfc1225)
 * [1651](https://tools.ietf.org/html/rfc1651): SMTP Service Extensions (Obsoletes rfc1425)
 * [1652](https://tools.ietf.org/html/rfc1652): SMTP Service Extension for 8bit-MIME transport (Obsoletes rfc1426)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -237,7 +237,7 @@
   IStoreLabelsRequest parameter. Made previous APIs into extension methods to aid in porting from 2.x.
 * Simplify Append()/AppendAsync() APIs by using a new IAppendRequest parameter instead. Made previous APIs into
   extension methods to aid in porting from 2.x.
-* Simplify Replace()/ReplaceAsync() APIs by using a new IReplaceRequest parameterinstead. Made previous APIs into
+* Simplify Replace()/ReplaceAsync() APIs by using a new IReplaceRequest parameter instead. Made previous APIs into
   extension methods to aid in porting from 2.x.
 * Updated SmtpClient.Send()/SendAsync() methods to return a string.
   (issue [#1161](https://github.com/jstedfast/MailKit/issues/1161))
@@ -251,7 +251,7 @@
 * Rewrote NTLM support based on official specs. Now supports channel-binding and using the default system credentials.
 * Modified ImapFolder.Fetch(int, int, ...) to shortcut if ImapFolder.Count == 0.
 * Updated SmtpClient to append an ORCPT arg to RCPT TO commands and to hex-encode the ENVID parameter value.
-* Improved/simplified logic for ranking SASL authentication mechisms for each client.
+* Improved/simplified logic for ranking SASL authentication mechanisms for each client.
 * Added SaslMechanism.ChallengeAsync() to facilitate future SASL mechanisms that may need to make network requests
   such as Kerberos/GSSAPI and perhaps even future/custom OAuth2 implementations.
 * Always set SearchResults.Count/Min/Max properties if we can.
@@ -358,7 +358,7 @@
   (issue [#1060](https://github.com/jstedfast/MailKit/issues/1060))
 * Make sure the ImapStream is not null (can be null if user calls Disconnect() causing IDLE to abort).
   (issue [#1025](https://github.com/jstedfast/MailKit/issues/1025))
-* Case-insenitively match IMAP folder attribute flags (e.g. \HasNoChildren and \NoSelect).
+* Case-insensitively match IMAP folder attribute flags (e.g. \HasNoChildren and \NoSelect).
 * Added support for the IMAP SAVEDATE extension.
 * Added support for detecting SMTP's REQUIRETLS extension.
 
@@ -415,7 +415,7 @@
 * Renamed MessageSummaryItems.Id to MessageSummaryItems.EmailId to
   better map to the property name used in the IMAP OBJECTID
   specification.
-* Updated NetworkStream.ReadAsync() and WriteAsync() mehods to make use of
+* Updated NetworkStream.ReadAsync() and WriteAsync() methods to make use of
   timeouts. (issue [#827](https://github.com/jstedfast/MailKit/issues/827))
 
 ## MailKit 2.5.2 (2020-03-14)
@@ -484,7 +484,7 @@ this release breaks API/ABI.
 
 ## MailKit 2.3.2 (2019-10-12)
 
-* Fixed trimming delimeters from the end of IMAP folder names.
+* Fixed trimming delimiters from the end of IMAP folder names.
 * Fixed fetching of IMAP PreviewText when message bodies do not contain any text parts.
 * Fixed Pop3Client to never emit Authenticated events w/ null messages.
 * Dropped SslProtocols.Tls (aka TLSv1.0) from the default SslProtocols used by IMAP, POP3
@@ -621,7 +621,7 @@ this release breaks API/ABI.
 * Made SmtpClient, Pop3Client, and ImapClient's Connect() methods truly cancellable as well
   as made the underlying socket.Connect() call adhere to any specified client.Timeout value.
 * Added support for connecting via a SOCKS4, SOCKS4a, or SOCKS5 proxy server.
-* Fixed ImapClient's OnAuthenticated() method to protect aganst throwing an ArgumentNullException
+* Fixed ImapClient's OnAuthenticated() method to protect against throwing an ArgumentNullException
   when trying to emit the Authenticated event if the server did not supply any resp-code-text in
   the OK response to the AUTHENTICATE command. (issue [#774](https://github.com/jstedfast/MailKit/issues/774))
 * Modified ImapFolder.Create() to handle [ALREADYEXISTS] resp-codes.
@@ -658,7 +658,7 @@ this release breaks API/ABI.
 * All ImapFolder.MessageFlagsChanged, ModSeqChanged, and LabelsChanged events will now also be
   followed by a MessageSummaryFetched event containing the combined information of those events.
 * Added support for IMAP's NOTIFY extension. Many thanks to [Steffen Kieß](https://github.com/steffen-kiess)
-  for getting the ball rolling on this feature by implementing the neccessary ImapEvent, ImapEventGroup,
+  for getting the ball rolling on this feature by implementing the necessary ImapEvent, ImapEventGroup,
   and ImapMailboxFilter classes as well as the initial support.
 
 API Changes Since 2.0.x:
@@ -760,7 +760,7 @@ client.Authenticate (oauth2);
 
 * Updated MailKit to fully support async IO instead of using Task.Run() wrappers.
 * Fixed a resource leak when fetching IMAP body parts gets an exception.
-* Fixed each of the Client.Connect() implementtions to catch exceptions thrown by
+* Fixed each of the Client.Connect() implementations to catch exceptions thrown by
   IProtocolLogger.LogConnect().
 * Removed the ImapFolder.MessagesArrived event.
 * Added new Authenticate() methods that take a SaslMechanism to avoid the need to

--- a/UnitTests/ExceptionTests.cs
+++ b/UnitTests/ExceptionTests.cs
@@ -91,7 +91,7 @@ namespace UnitTests {
 
 				var ex = (FolderNotOpenException) formatter.Deserialize (stream);
 				Assert.That (ex.FolderName, Is.EqualTo (expected.FolderName), "Unexpected FolderName.");
-				Assert.That (ex.FolderAccess, Is.EqualTo (expected.FolderAccess), "Unexpected FolderAcess.");
+				Assert.That (ex.FolderAccess, Is.EqualTo (expected.FolderAccess), "Unexpected FolderAccess.");
 			}
 
 			expected = new FolderNotOpenException ("Inbox", FolderAccess.ReadWrite, "This is the error message.");
@@ -103,7 +103,7 @@ namespace UnitTests {
 
 				var ex = (FolderNotOpenException) formatter.Deserialize (stream);
 				Assert.That (ex.FolderName, Is.EqualTo (expected.FolderName), "Unexpected FolderName.");
-				Assert.That (ex.FolderAccess, Is.EqualTo (expected.FolderAccess), "Unexpected FolderAcess.");
+				Assert.That (ex.FolderAccess, Is.EqualTo (expected.FolderAccess), "Unexpected FolderAccess.");
 			}
 
 			expected = new FolderNotOpenException ("Inbox", FolderAccess.ReadWrite, "This is the error message.", new IOException ("Inner Exception"));
@@ -115,7 +115,7 @@ namespace UnitTests {
 
 				var ex = (FolderNotOpenException) formatter.Deserialize (stream);
 				Assert.That (ex.FolderName, Is.EqualTo (expected.FolderName), "Unexpected FolderName.");
-				Assert.That (ex.FolderAccess, Is.EqualTo (expected.FolderAccess), "Unexpected FolderAcess.");
+				Assert.That (ex.FolderAccess, Is.EqualTo (expected.FolderAccess), "Unexpected FolderAccess.");
 			}
 
 			Assert.Throws<ArgumentNullException> (() => new FolderNotOpenException (null, FolderAccess.ReadOnly));

--- a/UnitTests/Net/Imap/ImapClientTests.cs
+++ b/UnitTests/Net/Imap/ImapClientTests.cs
@@ -3879,7 +3879,7 @@ namespace UnitTests.Net.Imap {
 			}
 		}
 
-		static List<ImapReplayCommand> CreateGetQuotaNonexistantQuotaRootCommands ()
+		static List<ImapReplayCommand> CreateGetQuotaNonexistentQuotaRootCommands ()
 		{
 			return new List<ImapReplayCommand> {
 				new ImapReplayCommand ("", "gmail.greeting.txt"),
@@ -3894,9 +3894,9 @@ namespace UnitTests.Net.Imap {
 		}
 
 		[Test]
-		public void TestGetQuotaNonexistantQuotaRoot ()
+		public void TestGetQuotaNonexistentQuotaRoot ()
 		{
-			var commands = CreateGetQuotaNonexistantQuotaRootCommands ();
+			var commands = CreateGetQuotaNonexistentQuotaRootCommands ();
 
 			using (var client = new ImapClient () { TagPrefix = 'A' }) {
 				try {
@@ -3945,9 +3945,9 @@ namespace UnitTests.Net.Imap {
 		}
 
 		[Test]
-		public async Task TestGetQuotaNonexistantQuotaRootAsync ()
+		public async Task TestGetQuotaNonexistentQuotaRootAsync ()
 		{
-			var commands = CreateGetQuotaNonexistantQuotaRootCommands ();
+			var commands = CreateGetQuotaNonexistentQuotaRootCommands ();
 
 			using (var client = new ImapClient () { TagPrefix = 'A' }) {
 				try {
@@ -4474,13 +4474,13 @@ namespace UnitTests.Net.Imap {
 
 				// COPY messages to the Destination folder
 				var copied = folder.CopyTo (uids, destination);
-				Assert.That (copied.Source, Has.Count.EqualTo (uids.Count), "Unexpetced Source.Count");
-				Assert.That (copied.Destination, Has.Count.EqualTo (uids.Count), "Unexpetced Destination.Count");
+				Assert.That (copied.Source, Has.Count.EqualTo (uids.Count), "Unexpected Source.Count");
+				Assert.That (copied.Destination, Has.Count.EqualTo (uids.Count), "Unexpected Destination.Count");
 
 				// MOVE messages to the Destination folder
 				var moved = folder.MoveTo (uids, destination);
-				Assert.That (copied.Source, Has.Count.EqualTo (uids.Count), "Unexpetced Source.Count");
-				Assert.That (copied.Destination, Has.Count.EqualTo (uids.Count), "Unexpetced Destination.Count");
+				Assert.That (copied.Source, Has.Count.EqualTo (uids.Count), "Unexpected Source.Count");
+				Assert.That (copied.Destination, Has.Count.EqualTo (uids.Count), "Unexpected Destination.Count");
 				Assert.That (vanished, Has.Count.EqualTo (1), "Expected VANISHED event");
 				vanished.Clear ();
 
@@ -5119,13 +5119,13 @@ namespace UnitTests.Net.Imap {
 
 				// COPY messages to the Destination folder
 				var copied = await folder.CopyToAsync (uids, destination);
-				Assert.That (copied.Source, Has.Count.EqualTo (uids.Count), "Unexpetced Source.Count");
-				Assert.That (copied.Destination, Has.Count.EqualTo (uids.Count), "Unexpetced Destination.Count");
+				Assert.That (copied.Source, Has.Count.EqualTo (uids.Count), "Unexpected Source.Count");
+				Assert.That (copied.Destination, Has.Count.EqualTo (uids.Count), "Unexpected Destination.Count");
 
 				// MOVE messages to the Destination folder
 				var moved = await folder.MoveToAsync (uids, destination);
-				Assert.That (copied.Source, Has.Count.EqualTo (uids.Count), "Unexpetced Source.Count");
-				Assert.That (copied.Destination, Has.Count.EqualTo (uids.Count), "Unexpetced Destination.Count");
+				Assert.That (copied.Source, Has.Count.EqualTo (uids.Count), "Unexpected Source.Count");
+				Assert.That (copied.Destination, Has.Count.EqualTo (uids.Count), "Unexpected Destination.Count");
 				Assert.That (vanished, Has.Count.EqualTo (1), "Expected VANISHED event");
 				vanished.Clear ();
 
@@ -6788,7 +6788,7 @@ namespace UnitTests.Net.Imap {
 				Assert.That (inbox.HighestModSeq, Is.EqualTo (3), "Inbox.HighestModSeq");
 
 				Assert.That (inboxHighestModSeqChanged, Is.EqualTo (1), "Inbox.HighestModSeqChanged");
-				Assert.That (inboxMetadataChanged, Is.EqualTo (1), "Inbbox.MetadataChanged");
+				Assert.That (inboxMetadataChanged, Is.EqualTo (1), "Inbox.MetadataChanged");
 				Assert.That (inboxCountChanged, Is.EqualTo (1), "Inbox.CountChanged");
 
 				Assert.That (created, Is.EqualTo (1), "FolderCreated");

--- a/UnitTests/Net/Imap/ImapFolderTests.cs
+++ b/UnitTests/Net/Imap/ImapFolderTests.cs
@@ -2055,7 +2055,7 @@ namespace UnitTests.Net.Imap {
 
 				try {
 					gmail.Create ("MyImportant", new[] { SpecialFolder.Important });
-					Assert.Fail ("Creating the MyImportamnt folder should have thrown an ImapCommandException");
+					Assert.Fail ("Creating the MyImportant folder should have thrown an ImapCommandException");
 				} catch (ImapCommandException ex) {
 					Assert.That (ex.Response, Is.EqualTo (ImapCommandResponse.No));
 					Assert.That (ex.ResponseText, Is.EqualTo ("An \\Important mailbox already exists"));
@@ -3050,7 +3050,7 @@ namespace UnitTests.Net.Imap {
 		}
 
 		[Test]
-		public async Task TestGetSuboldersWithStatusItemsAsync ()
+		public async Task TestGetSubfoldersWithStatusItemsAsync ()
 		{
 			var commands = CreateGetSubfoldersWithStatusItemsCommands ();
 

--- a/UnitTests/Net/Imap/ImapUtilsTests.cs
+++ b/UnitTests/Net/Imap/ImapUtilsTests.cs
@@ -716,7 +716,7 @@ namespace UnitTests.Net.Imap {
 		[Test]
 		public void TestParseEnvelopeWithMissingInReplyTo ()
 		{
-			const string text = "(\"Tue, 24 Sep 2019 09:48:05 +0800\" \"=?GBK?B?sbG+qdW9x/jI1bGose0=?=\" ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unkonwn-name\" \"unknown-domain\")) ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unkonwn-name\" \"unknown-domain\")) ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unkonwn-name\" \"unknown-domain\")) NIL NIL NIL)\r\n";
+			const string text = "(\"Tue, 24 Sep 2019 09:48:05 +0800\" \"=?GBK?B?sbG+qdW9x/jI1bGose0=?=\" ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unknown-name\" \"unknown-domain\")) ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unknown-name\" \"unknown-domain\")) ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unknown-name\" \"unknown-domain\")) NIL NIL NIL)\r\n";
 
 			using (var memory = new MemoryStream (Encoding.ASCII.GetBytes (text), false)) {
 				using (var tokenizer = new ImapStream (memory, new NullProtocolLogger ())) {
@@ -763,7 +763,7 @@ namespace UnitTests.Net.Imap {
 		[Test]
 		public async Task TestParseEnvelopeWithMissingInReplyToAsync ()
 		{
-			const string text = "(\"Tue, 24 Sep 2019 09:48:05 +0800\" \"=?GBK?B?sbG+qdW9x/jI1bGose0=?=\" ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unkonwn-name\" \"unknown-domain\")) ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unkonwn-name\" \"unknown-domain\")) ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unkonwn-name\" \"unknown-domain\")) NIL NIL NIL)\r\n";
+			const string text = "(\"Tue, 24 Sep 2019 09:48:05 +0800\" \"=?GBK?B?sbG+qdW9x/jI1bGose0=?=\" ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unknown-name\" \"unknown-domain\")) ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unknown-name\" \"unknown-domain\")) ((\"=?GBK?B?yv2+3bfWzvbQodfp?=\" NIL \"unknown-name\" \"unknown-domain\")) NIL NIL NIL)\r\n";
 
 			using (var memory = new MemoryStream (Encoding.ASCII.GetBytes (text), false)) {
 				using (var tokenizer = new ImapStream (memory, new NullProtocolLogger ())) {
@@ -1433,16 +1433,16 @@ namespace UnitTests.Net.Imap {
 						Assert.That (rfc822.ContentType.IsMimeType ("message", "rfc822"), Is.True, "message/rfc822 Content-Type did not match.");
 						Assert.That (rfc822.ContentId, Is.Null, "message/rfc822 Content-Id should be NIL.");
 						Assert.That (rfc822.ContentDescription, Is.Null, "message/rfc822 Content-Description should be NIL.");
-						Assert.That (rfc822.Envelope.Sender, Is.Empty, "message/rfc822 Envlope.Sender should be null.");
-						Assert.That (rfc822.Envelope.From, Is.Empty, "message/rfc822 Envlope.From should be null.");
-						Assert.That (rfc822.Envelope.ReplyTo, Is.Empty, "message/rfc822 Envlope.ReplyTo should be null.");
-						Assert.That (rfc822.Envelope.To, Is.Empty, "message/rfc822 Envlope.To should be null.");
-						Assert.That (rfc822.Envelope.Cc, Is.Empty, "message/rfc822 Envlope.Cc should be null.");
-						Assert.That (rfc822.Envelope.Bcc, Is.Empty, "message/rfc822 Envlope.Bcc should be null.");
-						Assert.That (rfc822.Envelope.Subject, Is.Null, "message/rfc822 Envlope.Subject should be null.");
-						Assert.That (rfc822.Envelope.MessageId, Is.Null, "message/rfc822 Envlope.MessageId should be null.");
-						Assert.That (rfc822.Envelope.InReplyTo, Is.Null, "message/rfc822 Envlope.InReplyTo should be null.");
-						Assert.That (rfc822.Envelope.Date, Is.Null, "message/rfc822 Envlope.Date should be null.");
+						Assert.That (rfc822.Envelope.Sender, Is.Empty, "message/rfc822 Envelope.Sender should be null.");
+						Assert.That (rfc822.Envelope.From, Is.Empty, "message/rfc822 Envelope.From should be null.");
+						Assert.That (rfc822.Envelope.ReplyTo, Is.Empty, "message/rfc822 Envelope.ReplyTo should be null.");
+						Assert.That (rfc822.Envelope.To, Is.Empty, "message/rfc822 Envelope.To should be null.");
+						Assert.That (rfc822.Envelope.Cc, Is.Empty, "message/rfc822 Envelope.Cc should be null.");
+						Assert.That (rfc822.Envelope.Bcc, Is.Empty, "message/rfc822 Envelope.Bcc should be null.");
+						Assert.That (rfc822.Envelope.Subject, Is.Null, "message/rfc822 Envelope.Subject should be null.");
+						Assert.That (rfc822.Envelope.MessageId, Is.Null, "message/rfc822 Envelope.MessageId should be null.");
+						Assert.That (rfc822.Envelope.InReplyTo, Is.Null, "message/rfc822 Envelope.InReplyTo should be null.");
+						Assert.That (rfc822.Envelope.Date, Is.Null, "message/rfc822 Envelope.Date should be null.");
 						Assert.That (rfc822.ContentTransferEncoding, Is.EqualTo ("7BIT"), "message/rfc822 encoding did not match.");
 						Assert.That (rfc822.Octets, Is.EqualTo (787), "message/rfc822 octets did not match.");
 						Assert.That (rfc822.Body, Is.Null, "message/rfc822 body should be null.");
@@ -1502,16 +1502,16 @@ namespace UnitTests.Net.Imap {
 						Assert.That (rfc822.ContentType.IsMimeType ("message", "rfc822"), Is.True, "message/rfc822 Content-Type did not match.");
 						Assert.That (rfc822.ContentId, Is.Null, "message/rfc822 Content-Id should be NIL.");
 						Assert.That (rfc822.ContentDescription, Is.Null, "message/rfc822 Content-Description should be NIL.");
-						Assert.That (rfc822.Envelope.Sender, Is.Empty, "message/rfc822 Envlope.Sender should be null.");
-						Assert.That (rfc822.Envelope.From, Is.Empty, "message/rfc822 Envlope.From should be null.");
-						Assert.That (rfc822.Envelope.ReplyTo, Is.Empty, "message/rfc822 Envlope.ReplyTo should be null.");
-						Assert.That (rfc822.Envelope.To, Is.Empty, "message/rfc822 Envlope.To should be null.");
-						Assert.That (rfc822.Envelope.Cc, Is.Empty, "message/rfc822 Envlope.Cc should be null.");
-						Assert.That (rfc822.Envelope.Bcc, Is.Empty, "message/rfc822 Envlope.Bcc should be null.");
-						Assert.That (rfc822.Envelope.Subject, Is.Null, "message/rfc822 Envlope.Subject should be null.");
-						Assert.That (rfc822.Envelope.MessageId, Is.Null, "message/rfc822 Envlope.MessageId should be null.");
-						Assert.That (rfc822.Envelope.InReplyTo, Is.Null, "message/rfc822 Envlope.InReplyTo should be null.");
-						Assert.That (rfc822.Envelope.Date, Is.Null, "message/rfc822 Envlope.Date should be null.");
+						Assert.That (rfc822.Envelope.Sender, Is.Empty, "message/rfc822 Envelope.Sender should be null.");
+						Assert.That (rfc822.Envelope.From, Is.Empty, "message/rfc822 Envelope.From should be null.");
+						Assert.That (rfc822.Envelope.ReplyTo, Is.Empty, "message/rfc822 Envelope.ReplyTo should be null.");
+						Assert.That (rfc822.Envelope.To, Is.Empty, "message/rfc822 Envelope.To should be null.");
+						Assert.That (rfc822.Envelope.Cc, Is.Empty, "message/rfc822 Envelope.Cc should be null.");
+						Assert.That (rfc822.Envelope.Bcc, Is.Empty, "message/rfc822 Envelope.Bcc should be null.");
+						Assert.That (rfc822.Envelope.Subject, Is.Null, "message/rfc822 Envelope.Subject should be null.");
+						Assert.That (rfc822.Envelope.MessageId, Is.Null, "message/rfc822 Envelope.MessageId should be null.");
+						Assert.That (rfc822.Envelope.InReplyTo, Is.Null, "message/rfc822 Envelope.InReplyTo should be null.");
+						Assert.That (rfc822.Envelope.Date, Is.Null, "message/rfc822 Envelope.Date should be null.");
 						Assert.That (rfc822.ContentTransferEncoding, Is.EqualTo ("7BIT"), "message/rfc822 encoding did not match.");
 						Assert.That (rfc822.Octets, Is.EqualTo (787), "message/rfc822 octets did not match.");
 						Assert.That (rfc822.Body, Is.Null, "message/rfc822 body should be null.");

--- a/UnitTests/Net/Smtp/SmtpClientTests.cs
+++ b/UnitTests/Net/Smtp/SmtpClientTests.cs
@@ -3620,7 +3620,7 @@ namespace UnitTests.Net.Smtp {
 			}
 		}
 
-		static List<SmtpReplayCommand> CreatetPipeliningCommands ()
+		static List<SmtpReplayCommand> CreatePipeliningCommands ()
 		{
 			return new List<SmtpReplayCommand> {
 				new SmtpReplayCommand ("", "comcast-greeting.txt"),
@@ -3637,7 +3637,7 @@ namespace UnitTests.Net.Smtp {
 		[TestCase (true, TestName = "TestPipeliningWithProgress")]
 		public void TestPipelining (bool showProgress)
 		{
-			var commands = CreatetPipeliningCommands ();
+			var commands = CreatePipeliningCommands ();
 
 			using (var client = new SmtpClient ()) {
 				try {
@@ -3695,7 +3695,7 @@ namespace UnitTests.Net.Smtp {
 		[TestCase (true, TestName = "TestPipeliningAsyncWithProgress")]
 		public async Task TestPipeliningAsync (bool showProgress)
 		{
-			var commands = CreatetPipeliningCommands ();
+			var commands = CreatePipeliningCommands ();
 
 			using (var client = new SmtpClient ()) {
 				try {

--- a/UnitTests/Security/Ntlm/NtlmTargetInfoTests.cs
+++ b/UnitTests/Security/Ntlm/NtlmTargetInfoTests.cs
@@ -150,7 +150,7 @@ namespace UnitTests.Security.Ntlm {
 		};
 
 		[Test]
-		public void TestDecodeUnorederedOem ()
+		public void TestDecodeUnorderedOem ()
 		{
 			AssertDecode (NtlmTargetInfoUnorderedOem, false);
 		}
@@ -174,7 +174,7 @@ namespace UnitTests.Security.Ntlm {
 		};
 
 		[Test]
-		public void TestDecodeUnorderedUnocode ()
+		public void TestDecodeUnorderedUnicode ()
 		{
 			AssertDecode (NtlmTargetInfoUnorderedUnicode, true);
 		}
@@ -228,9 +228,9 @@ namespace UnitTests.Security.Ntlm {
 				Assert.That (targetInfo.ChannelBinding[i], Is.EqualTo (channelBinding[i]), $"ChannelBinding[{i}]");
 
 			targetInfo.ServerName = null;
-			Assert.That (targetInfo.ServerName, Is.Null, "SserverName remove attempt #1");
+			Assert.That (targetInfo.ServerName, Is.Null, "ServerName remove attempt #1");
 			targetInfo.ServerName = null;
-			Assert.That (targetInfo.ServerName, Is.Null, "ServerNamet remove attempt #2");
+			Assert.That (targetInfo.ServerName, Is.Null, "ServerName remove attempt #2");
 
 			targetInfo.SingleHost = null;
 			Assert.That (targetInfo.SingleHost, Is.Null, "SingleHost remove attempt #1");

--- a/nuget/GettingStarted.md
+++ b/nuget/GettingStarted.md
@@ -226,7 +226,7 @@ foreach (var folder in personal.GetSubfolders (false))
 	Console.WriteLine ("[folder] {0}", folder.Name);
 ```
 
-If the IMAP server supports the SPECIAL-USE or the XLIST (GMail) extension, you can get ahold of
+If the IMAP server supports the SPECIAL-USE or the XLIST (GMail) extension, you can get a hold of
 the pre-defined All, Drafts, Flagged (aka Important), Junk, Sent, Trash, etc folders like this:
 
 ```csharp

--- a/samples/ImapClientDemo.iOS/ImapClientDemo.iOS/SceneDelegate.cs
+++ b/samples/ImapClientDemo.iOS/ImapClientDemo.iOS/SceneDelegate.cs
@@ -20,7 +20,7 @@ public class SceneDelegate : UIResponder, IUIWindowSceneDelegate {
 		// Called as the scene is being released by the system.
 		// This occurs shortly after the scene enters the background, or when its session is discarded.
 		// Release any resources associated with this scene that can be re-created the next time the scene connects.
-		// The scene may re-connect later, as its session was not neccessarily discarded (see UIApplicationDelegate `DidDiscardSceneSessions` instead).
+		// The scene may re-connect later, as its session was not necessarily discarded (see UIApplicationDelegate `DidDiscardSceneSessions` instead).
 	}
 
 	[Export ("sceneDidBecomeActive:")]


### PR DESCRIPTION
Just thought I'd contribute some typo fixes I stumbled upon. Nothing controversial (hopefully), just 171 simple fixes.

Use the following command to get a quick and dirty summary of the specific corrections made:
```shell
git diff HEAD^! --word-diff-regex='\w+' -U0 \
  | grep -E '\[\-.*\-\]\{\+.*\+\}' \
  | sed -r 's/.*\[\-(.*)\-\]\{\+(.*)\+\}.*/\1 \2/' \
  | sort | uniq -c | sort -n
```

FWIW, the top typos are:
* strting (30)
* envlope (20)
* unexpetced (8)
* miliseconds (8)
* posession (6)
* nonexistant (5)
* retreiving (4)
* spontanious (4)
* fsubset (4)
* createt (3)
* acess (3)
* durring (3)
* delimeter (3)