### PR TITLE
Support for WebProxies without Credentials

### DIFF
--- a/MailKit/Net/Proxy/WebProxyClient.cs
+++ b/MailKit/Net/Proxy/WebProxyClient.cs
@@ -140,7 +140,7 @@ namespace MailKit.Net.Proxy
 			var targetUri = GetTargetUri (host, port);
 			var proxyUri = proxy.GetProxy (targetUri);
 
-			if (proxyUri is null) {
+			if (proxyUri is null || proxy.IsBypassed (targetUri)) {
 				// Note: if the proxy URI is null, then it means that the proxy should be bypassed.
 				var socket = SocketUtils.Connect (host, port, LocalEndPoint, cancellationToken);
 				return new NetworkStream (socket, true);
@@ -186,7 +186,7 @@ namespace MailKit.Net.Proxy
 			var targetUri = GetTargetUri (host, port);
 			var proxyUri = proxy.GetProxy (targetUri);
 
-			if (proxyUri is null) {
+			if (proxyUri is null || proxy.IsBypassed (targetUri)) {
 				// Note: if the proxy URI is null, then it means that the proxy should be bypassed.
 				var socket = await SocketUtils.ConnectAsync (host, port, LocalEndPoint, cancellationToken).ConfigureAwait (false);
 				return new NetworkStream (socket, true);


### PR DESCRIPTION
If the Application uses a WebProxy without credentials (e.g. http://172.x.x.x:8080), the credentials.GetCredentials call throwed an NullReference exception. So added a null check therefore. 

Also added checks for the ProxyBypassList (e.g NO_PROXY env).

