### PR TITLE
Make MailService::GetSslClientAuthenticationOptions protected virtual

### DIFF
--- a/MailKit/MailService.cs
+++ b/MailKit/MailService.cs
@@ -576,7 +576,7 @@ namespace MailKit {
 		/// <param name="host">The target host that the client is connected to.</param>
 		/// <param name="remoteCertificateValidationCallback">The remote certificate validation callback.</param>
 		/// <returns>The client SSL/TLS authentication options.</returns>
-		protected SslClientAuthenticationOptions GetSslClientAuthenticationOptions (string host, RemoteCertificateValidationCallback remoteCertificateValidationCallback)
+		protected virtual SslClientAuthenticationOptions GetSslClientAuthenticationOptions (string host, RemoteCertificateValidationCallback remoteCertificateValidationCallback)
 		{
 			return new SslClientAuthenticationOptions {
 				CertificateRevocationCheckMode = CheckCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,


### PR DESCRIPTION
A small summary for a small change:

In .NET 8, when connecting to a relay server using an IP address that was manually resolved from a hostname, the TargetHost property ends up being the IP address. As a result, the Server Name Indication (SNI) is not included in the Client Hello message.

# TLS Certificate Mismatch Due to Missing SNI
When connecting to the MX record for dummy.com.ec, the server responds with server.whatever.com. Without using SNI, the TLS handshake returns a certificate for server.whatever.com, which does not match the expected domain dummy.com.ec, causing a TLS mismatch. However, when SNI is used with dummy.com.ec as the server name, the correct wildcard certificate for *.dummy.com.ec is returned, and the connection succeeds.

# Solution: Solution: Make GetSslClientAuthenticationOptions Overridable
If the method that creates SslClientAuthenticationOptions is made virtual, it can be overridden to assign the correct hostname as TargetHost. This allows the use of SNI and ensures that the correct certificate is served during TLS negotiation.

Regards,
Juanje