### PR TITLE
Fix unmanaged resource leak in NTLM RC4 key generation

### DIFF
--- a/MailKit/Security/Ntlm/RC4.cs
+++ b/MailKit/Security/Ntlm/RC4.cs
@@ -105,7 +105,9 @@ namespace MailKit.Security.Ntlm {
 		public override void GenerateKey ()
 		{
 			key = new byte[KeySizeValue >> 3];
-			RandomNumberGenerator.Create ().GetBytes (key);
+			using (var rng = RandomNumberGenerator.Create ()) {
+				rng.GetBytes (key);
+			}
 			KeySetup (key);
 		}
 


### PR DESCRIPTION
`RandomNumberGenerator.Create()` allocates unmanaged cryptographic resources (e.g., CSP handles on Windows) in `RC4.GenerateKey()`, but `Dispose()` is not explicitly called. 

In high-throughput scenarios or cyclic calls, this can lead to resource exhaustion before the Garbage Collector has a chance to run the finalizers. 

Wrapped the `RandomNumberGenerator.Create()` instantiation in a `using` block to ensure deterministic disposal of the cryptographic resources.

*Found by Linux Verification Center (linuxtesting.org) with SVACE.*