### PR TITLE
Fix unused 'network' variable in SmtpStream.ReadAheadAsync

### DIFF
--- a/MailKit/Net/Smtp/SmtpStream.cs
+++ b/MailKit/Net/Smtp/SmtpStream.cs
@@ -262,8 +262,6 @@ namespace MailKit.Net.Smtp {
 			AlignReadAheadBuffer (out int offset, out int count);
 
 			try {
-				var network = Stream as NetworkStream;
-
 				cancellationToken.ThrowIfCancellationRequested ();
 
 				int nread = await Stream.ReadAsync (input, offset, count, cancellationToken).ConfigureAwait (false);


### PR DESCRIPTION
Removed the unused `network` variable in `SmtpStream.ReadAheadAsync`. It seems to be a leftover from the synchronous `ReadAhead` method and was triggering a static analyzer warning.

Found by Linux Verification Center (linuxtesting.org) with SVACE.