### PR TITLE
Add [NotNull] annotation and explanation to ImapClient.Inbox

### DIFF
--- a/MailKit/Net/Imap/ImapClient.cs
+++ b/MailKit/Net/Imap/ImapClient.cs
@@ -2247,13 +2247,22 @@ namespace MailKit.Net.Imap {
 		/// <exception cref="ServiceNotAuthenticatedException">
 		/// The <see cref="ImapClient"/> is not authenticated.
 		/// </exception>
+		// Declared as IMailFolder? to match the nullable underlying ImapEngine.Inbox field, but this
+		// property never returns null in practice. CheckAuthenticated() throws ServiceNotAuthenticatedException
+		// before engine.Inbox is reached if the client is not authenticated:
+		//   https://github.com/jstedfast/MailKit/blob/33f045be0f64a255fe153acd640af37d80c0ede3/MailKit/Net/Imap/ImapClient.cs#L2250-L2257
+		// engine.Inbox is guaranteed non-null by the time authentication completes — QuerySpecialFolders()
+		// always assigns it before Authenticate() returns, creating a placeholder if the server never reported one:
+		//   https://github.com/jstedfast/MailKit/blob/33f045be0f64a255fe153acd640af37d80c0ede3/MailKit/Net/Imap/ImapEngine.cs#L3762-L3768
+		// engine.Inbox is never reassigned null after that point, so it remains non-null for the session lifetime.
+		[NotNull]
 		public override IMailFolder? Inbox {
 			get {
 				CheckDisposed ();
 				CheckConnected ();
 				CheckAuthenticated ();
 
-				return engine.Inbox;
+				return engine.Inbox!;
 			}
 		}
 


### PR DESCRIPTION
## Summary

- `ImapClient.Inbox` is typed as `IMailFolder?` to match the nullable `ImapEngine.Inbox` field, but the property never actually returns `null` in practice
- Adds `[NotNull]` so the compiler can surface this guarantee to callers using the concrete `ImapClient` type, eliminating spurious null warnings
- Adds a comment explaining the reasoning with permalinks to the relevant code

## Why it never returns null

1. `CheckAuthenticated()` throws `ServiceNotAuthenticatedException` before `engine.Inbox` is ever reached if the client is unauthenticated
2. `Authenticate()` calls `OnAuthenticated()` → `QuerySpecialFolders()` synchronously before returning, which always assigns `engine.Inbox` — creating a placeholder folder if the server never reported one ([ImapEngine.cs#L3762-L3768](https://github.com/jstedfast/MailKit/blob/33f045be0f64a255fe153acd640af37d80c0ede3/MailKit/Net/Imap/ImapEngine.cs#L3762-L3768))
3. `engine.Inbox` is never reassigned `null` after that point

## Test plan

- [ ] Existing IMAP unit tests pass
- [ ] Callers accessing `ImapClient.Inbox` directly no longer receive a nullable warning from the compiler

🤖 Generated with [Claude Code](https://claude.com/claude-code)