### PR TITLE
Update NegotiateAuthenticationStatusCode check condition inside CheckSupported() method to fix NativeNtlmSupported & GssapiSupported flags initialization

### DIFF
--- a/MailKit/Security/SaslMechanismNegotiateBase.cs
+++ b/MailKit/Security/SaslMechanismNegotiateBase.cs
@@ -398,7 +398,8 @@ namespace MailKit.Security
 				using (var negotiate = new NegotiateAuthentication (options))
 					negotiate.GetOutgoingBlob (Array.Empty<byte> (), out statusCode);
 
-				return statusCode == NegotiateAuthenticationStatusCode.Completed;
+				return statusCode == NegotiateAuthenticationStatusCode.ContinueNeeded
+					|| statusCode == NegotiateAuthenticationStatusCode.Completed;
 			} catch {
 				return false;
 			}


### PR DESCRIPTION
Fix NTLM native support detection for NegotiateAuthentication.

`SaslMechanismNegotiateBase.CheckSupported()` currently treats NTLM as supported only when the initial `GetOutgoingBlob()` call returns `NegotiateAuthenticationStatusCode.Completed`.

However, `NTLM` is typically a multi-step challenge-response protocol, and a successful first call commonly returns `NegotiateAuthenticationStatusCode.ContinueNeeded`, indicating that `NTLM` is available and negotiation has started successfully.

As a result, native `NTLM` support may be incorrectly considered unavailable, causing **MailKit** to fall back to the managed `NTLM` implementation (which unfortunately doesn't work with `CredentialCache.DefaultNetworkCredentials` and needs explicit credentials).

Consider both `ContinueNeeded` and `Completed` as successful capability probe results:
```cs
return statusCode == NegotiateAuthenticationStatusCode.ContinueNeeded
    || statusCode == NegotiateAuthenticationStatusCode.Completed;
```

This change affects only capability detection and does not modify the authentication flow itself.

P.S. Looks like that the proper implementation have to check that resulting status is not equal to `NegotiateAuthenticationStatusCode.Unsupported`. But proposed change is much safer and it fixes only the specific issue I have as a **MailKit** package user